### PR TITLE
Cannot save nodes of type article

### DIFF
--- a/modules/markaspot_request_id/markaspot_request_id.module
+++ b/modules/markaspot_request_id/markaspot_request_id.module
@@ -79,13 +79,11 @@ function markaspot_request_id_node_presave(EntityInterface $node) {
     // $language = \Drupal::languageManager()->getCurrentLanguage()->getId();
     $request_id = marakaspot_request_id_create_request_id();
     $node->request_id = $request_id;
+    $request_id = $node->request_id->value;
+    $title = markaspot_request_id_create_title($node, $request_id);
+    markaspot_request_id_update_table($node, $title, $request_id);
+    $node->title = $title;
   }
-  $request_id = $node->request_id->value;
-  $title = markaspot_request_id_create_title($node, $request_id);
-  markaspot_request_id_update_table($node, $title, $request_id);
-
-  $node->title = $title;
-
 }
 
 function markaspot_request_id_update_table($node, $title, $request_id) {


### PR DESCRIPTION
When you try to save nodes (nodetype != service_request) you will get the following error:

`Drupal\Core\Entity\EntityStorageException: SQLSTATE[23000]: Integrity constraint violation: 1048 Column 'title' cannot be null: UPDATE {node_field_data} SET title=:db_update_placeholder_0, request_id=:db_update_placeholder_1 WHERE nid = :db_condition_placeholder_0; Array ( [:db_update_placeholder_0] => [:db_update_placeholder_1] => [:db_condition_placeholder_0] => 47 ) in Drupal\Core\Entity\Sql\SqlContentEntityStorage->save() (line 846 of core/lib/Drupal/Core/Entity/Sql/SqlContentEntityStorage.php).`