### PR TITLE
feat(passwordless): expose jurisdiction slug on auth_user.groups

### DIFF
--- a/modules/markaspot_mail/markaspot_mail.services.yml
+++ b/modules/markaspot_mail/markaspot_mail.services.yml
@@ -13,6 +13,7 @@ services:
       - '@logger.channel.markaspot_mail'
       - '@extension.list.module'
       - '@request_stack'
+      - '@file_system'
 
   markaspot_mail.renderer:
     class: Drupal\markaspot_mail\Service\MailHtmlRenderer

--- a/modules/markaspot_mail/src/Mail/Builder/PasswordlessOtpBuilder.php
+++ b/modules/markaspot_mail/src/Mail/Builder/PasswordlessOtpBuilder.php
@@ -94,34 +94,52 @@ final class PasswordlessOtpBuilder implements MailBuilderInterface {
     $replacements = [
       '@code' => $code,
       '@expires_in' => $expiresIn,
+      '@minutes' => $expiresIn,
       '@platform_name' => $platformName,
     ];
 
-    // The subject template explicitly drops @code. Admins who customize
-    // the subject config could otherwise write "@platform_name: @code"
-    // and leak the OTP into the mail-subject header, which travels in
-    // cleartext SMTP, appears in inbox-preview notifications, gets
-    // logged at MTAs, and is often indexed by mail providers. Body +
-    // plainText keep the @code placeholder; only the header-bound slot
-    // drops it here.
+    // The subject and preheader templates explicitly drop @code. Admins who
+    // customize config could otherwise leak the OTP into headers, previews,
+    // notifications, MTA logs, and indexed provider metadata. Body +
+    // plainText keep @code; header/preview-bound slots do not.
     $subjectReplacements = array_diff_key($replacements, ['@code' => TRUE]);
     $subject = $this->resolveFromConfig('subject', $subjectReplacements, $langcode)
       ?: (string) $this->t('@platform_name: Your verification code', [
         '@platform_name' => $platformName,
       ], ['langcode' => $langcode]);
 
+    $preheader = $this->resolvePreheaderFromConfig($subjectReplacements, $langcode)
+      ?: $this->deriveLegacyBodyPreview($replacements, $langcode)
+      ?: $this->resolvePreheaderFromBaseConfig($subjectReplacements)
+      ?: (string) $this->t('Your verification code expires in @minutes minutes.', [
+        '@minutes' => $expiresIn,
+      ], ['langcode' => $langcode]);
+    $headline = $this->resolveFromConfig('headline', $replacements, $langcode, FALSE)
+      ?: $this->deriveHeadlineFromSubject($subjectReplacements, $langcode)
+      ?: $this->resolveFromConfig('headline', $replacements, $langcode)
+      ?: (string) $this->t('Verify your account', [], ['langcode' => $langcode]);
+    $subtext = $this->resolveFromConfig('subtext', $replacements, $langcode, FALSE)
+      ?: $this->deriveLegacyBodySubtext($replacements, $langcode)
+      ?: $this->resolveFromConfig('subtext', $replacements, $langcode)
+      ?: (string) $this->t('Enter this code in the next @minutes minutes. If you did not request this, you can ignore this email.', [
+        '@minutes' => $expiresIn,
+      ], ['langcode' => $langcode]);
+    $plainText = $this->resolveFromConfig('plain_text', $replacements, $langcode, FALSE)
+      ?: $this->resolveFromConfig('body', $replacements, $langcode, FALSE)
+      ?: $this->resolveFromConfig('plain_text', $replacements, $langcode)
+      ?: (string) $this->t("Your verification code: @code\n\nIt expires in @minutes minutes.", [
+        '@code' => $code,
+        '@minutes' => $expiresIn,
+      ], ['langcode' => $langcode]);
+
     return new MailMessage(
       subject: $subject,
       variant: 'hero_code',
       content: [
-        'preheader' => (string) $this->t('Your verification code: @code', [
-          '@code' => $code,
-        ], ['langcode' => $langcode]),
-        'headline' => (string) $this->t('Verify your account', [], ['langcode' => $langcode]),
+        'preheader' => $preheader,
+        'headline' => $headline,
         'code' => $this->formatCodeForDisplay($code),
-        'subtext' => (string) $this->t('Enter this code in the next @minutes minutes. If you did not request this, you can ignore this email.', [
-          '@minutes' => $expiresIn,
-        ], ['langcode' => $langcode]),
+        'subtext' => $subtext,
       ],
       mode: $mode,
       jurisdictionId: $jurisdictionId,
@@ -129,15 +147,12 @@ final class PasswordlessOtpBuilder implements MailBuilderInterface {
       // text works, but the space-separated code that looks great in the
       // monospaced hero reads awkwardly at the inbox preview / SMS
       // fallback level. Keep the plain body compact.
-      plainText: (string) $this->t("Your verification code: @code\n\nIt expires in @minutes minutes.", [
-        '@code' => $code,
-        '@minutes' => $expiresIn,
-      ], ['langcode' => $langcode]),
+      plainText: $plainText,
     );
   }
 
   /**
-   *
+   * Formats the OTP code for display in the hero block.
    */
   private function formatCodeForDisplay(string $code): string {
     return $code;
@@ -146,19 +161,131 @@ final class PasswordlessOtpBuilder implements MailBuilderInterface {
   /**
    * Reads a config template and substitutes @placeholders.
    */
-  private function resolveFromConfig(string $key, array $replacements, string $langcode): string {
+  private function resolveFromConfig(string $key, array $replacements, string $langcode, bool $fallbackToBase = TRUE): string {
+    $template = $this->readConfigTemplate($key, $langcode, $fallbackToBase);
+    return $template !== '' ? (string) strtr($template, $replacements) : '';
+  }
+
+  /**
+   * Reads a raw config template.
+   */
+  private function readConfigTemplate(string $key, string $langcode, bool $fallbackToBase = TRUE): string {
     $config = $this->languageManager
       ->getLanguageConfigOverride($langcode, 'markaspot_passwordless.mail')
       ->get('verification_code');
-    if (!is_array($config) || empty($config[$key])) {
-      $config = $this->configFactory
-        ->get('markaspot_passwordless.mail')
-        ->get('verification_code');
+    if (is_array($config) && !empty($config[$key])) {
+      return (string) $config[$key];
     }
-    if (!is_array($config) || empty($config[$key])) {
+    if (!$fallbackToBase) {
       return '';
     }
-    return (string) strtr((string) $config[$key], $replacements);
+
+    $config = $this->configFactory
+      ->get('markaspot_passwordless.mail')
+      ->get('verification_code');
+    return is_array($config) && !empty($config[$key]) ? (string) $config[$key] : '';
+  }
+
+  /**
+   * Reads preheader config without allowing @code to leak into previews.
+   */
+  private function resolvePreheaderFromConfig(array $replacements, string $langcode): string {
+    $template = $this->readConfigTemplate('preheader', $langcode, FALSE);
+    if ($template === '') {
+      return '';
+    }
+    return (string) strtr($this->stripCodePlaceholder($template), $replacements);
+  }
+
+  /**
+   * Reads the base preheader without allowing @code to leak into previews.
+   */
+  private function resolvePreheaderFromBaseConfig(array $replacements): string {
+    $config = $this->configFactory
+      ->get('markaspot_passwordless.mail')
+      ->get('verification_code');
+    if (!is_array($config) || empty($config['preheader'])) {
+      return '';
+    }
+    return (string) strtr($this->stripCodePlaceholder((string) $config['preheader']), $replacements);
+  }
+
+  /**
+   * Derives a localized headline from legacy subject config.
+   */
+  private function deriveHeadlineFromSubject(array $replacements, string $langcode): string {
+    $template = $this->readConfigTemplate('subject', $langcode, FALSE);
+    if ($template === '') {
+      return '';
+    }
+    $subject = trim((string) strtr($template, $replacements));
+    $platformName = (string) ($replacements['@platform_name'] ?? '');
+    if ($platformName !== '' && str_starts_with($subject, $platformName . ':')) {
+      return trim(substr($subject, strlen($platformName) + 1));
+    }
+    if (str_contains($subject, ':')) {
+      return trim((string) preg_replace('/^.*?:\s*/', '', $subject, 1));
+    }
+    return $subject;
+  }
+
+  /**
+   * Derives a localized inbox preview from legacy body config.
+   */
+  private function deriveLegacyBodyPreview(array $replacements, string $langcode): string {
+    $line = $this->firstLegacyBodyLineWithoutCode($langcode);
+    return $line !== '' ? (string) strtr($line, $replacements) : '';
+  }
+
+  /**
+   * Derives localized hero support text from legacy body config.
+   */
+  private function deriveLegacyBodySubtext(array $replacements, string $langcode): string {
+    $lines = $this->legacyBodyLinesWithoutCode($langcode);
+    return $lines !== [] ? (string) strtr(implode(' ', $lines), $replacements) : '';
+  }
+
+  /**
+   * Returns the first non-code line from legacy body config.
+   */
+  private function firstLegacyBodyLineWithoutCode(string $langcode): string {
+    $lines = $this->legacyBodyLinesWithoutCode($langcode);
+    return $lines[0] ?? '';
+  }
+
+  /**
+   * Returns non-empty legacy body lines that do not contain the OTP code.
+   *
+   * Older locale overrides only shipped subject/body. Reusing their non-code
+   * body lines keeps localized mails localized until a site adds the newer
+   * headline, preheader, subtext and plain_text keys.
+   *
+   * @return string[]
+   *   Body lines without @code.
+   */
+  private function legacyBodyLinesWithoutCode(string $langcode): array {
+    $template = $this->readConfigTemplate('body', $langcode, FALSE);
+    if ($template === '') {
+      return [];
+    }
+    $lines = preg_split('/\R+/', $template) ?: [];
+    $filtered = [];
+    foreach ($lines as $line) {
+      $line = trim((string) $line);
+      if ($line === '' || str_contains($line, '@code')) {
+        continue;
+      }
+      $filtered[] = $line;
+    }
+    return $filtered;
+  }
+
+  /**
+   * Removes the OTP placeholder from preview-bound templates.
+   */
+  private function stripCodePlaceholder(string $template): string {
+    $stripped = (string) preg_replace('/\s*[:-]?\s*@code\b/', '', $template);
+    return trim($stripped);
   }
 
 }

--- a/modules/markaspot_mail/src/Mail/SplitParagraphsTrait.php
+++ b/modules/markaspot_mail/src/Mail/SplitParagraphsTrait.php
@@ -50,10 +50,31 @@ trait SplitParagraphsTrait {
     foreach ($raw as $paragraph) {
       $paragraph = trim($paragraph);
       if ($paragraph !== '') {
-        $out[] = Markup::create(Xss::filter($paragraph, self::MAIL_ALLOWED_TAGS));
+        $filtered = Xss::filter($paragraph, self::MAIL_ALLOWED_TAGS);
+        if ($this->shouldPreserveSingleLineBreaks($filtered)) {
+          $filtered = str_replace(["\r\n", "\r"], "\n", $filtered);
+          $filtered = str_replace("\n", '<br>', $filtered);
+        }
+        $out[] = Markup::create($filtered);
       }
     }
     return $out;
+  }
+
+  /**
+   * Determines whether plain-text line breaks should become <br> tags.
+   *
+   * ECA bodies often mix plain labels and values in one paragraph:
+   * "Address:\nStreet\nCity". HTML collapses those newlines to spaces,
+   * so we preserve them as <br>. If the operator already authored block
+   * or list HTML, we leave it alone to avoid invalid shapes like
+   * "<ul><br><li>...".
+   */
+  private function shouldPreserveSingleLineBreaks(string $html): bool {
+    if (!str_contains($html, "\n") && !str_contains($html, "\r")) {
+      return FALSE;
+    }
+    return preg_match('#<(br|/?(?:p|ul|ol|li|h2|h3))\b#i', $html) !== 1;
   }
 
 }

--- a/modules/markaspot_mail/src/Service/MailBrandingService.php
+++ b/modules/markaspot_mail/src/Service/MailBrandingService.php
@@ -367,10 +367,9 @@ class MailBrandingService {
       $isSaas ? 'https://civicpatches.de/datenschutz' : '',
     );
 
-    // Logo: platform logo ships inside the module as a PNG asset. If the
-    // file doesn't exist on disk we still hand back the URL; downstream the
-    // template will render an alt-text fallback. We don't want branding
-    // resolution to hard-fail on a missing static asset.
+    // Logo: platform logo ships inside the module as a PNG asset. Only hand
+    // back module-local paths when the file exists, because PHPMailer embeds
+    // relative images and can fail formatting on unreadable files.
     $logoPath = (string) ($settings->get('platform.logo_path') ?? 'images/mark-a-spot-logo@2x.png');
     $logoUrl = $this->buildModuleAssetUrl($logoPath);
 
@@ -757,7 +756,7 @@ class MailBrandingService {
   }
 
   /**
-   * Resolves a logo asset reference to an absolute URL.
+   * Resolves a logo asset reference for mail rendering.
    *
    * Accepts two input shapes:
    * - Absolute http(s) URL (e.g. a tenant-uploaded wappen served from the
@@ -766,10 +765,13 @@ class MailBrandingService {
    *   are not detected here and fall into the module-asset branch where
    *   they render as a broken URL — caller validates source.
    * - Module-relative asset path (e.g. images/mark-a-spot-logo@2x.png).
-   *   Resolved to an absolute URL via ModuleExtensionList + RequestStack;
-   *   falls back to a relative URL when those services are unavailable
-   *   (e.g. under unit tests). Mail clients treat relative URLs poorly,
-   *   so production always runs with both services wired.
+   *   Resolved to a Drupal-root-relative URL. phpmailer_smtp passes the
+   *   rendered HTML through PHPMailer::msgHTML($html, DRUPAL_ROOT), and
+   *   PHPMailer only embeds relative local image paths. Keeping module
+   *   assets relative here lets the mailer convert them to cid: images
+   *   instead of making inbox clients fetch a public HTTP URL. Missing
+   *   module-local assets return an empty string so Twig renders the text
+   *   fallback and mail delivery still succeeds.
    */
   private function buildModuleAssetUrl(string $relative): string {
     // Allow tenants to point platform.logo_path at an absolute URL (e.g. a
@@ -780,6 +782,12 @@ class MailBrandingService {
       return $this->ensureAbsolute($relative) ?? $relative;
     }
     $relative = ltrim($relative, '/');
+    if ($relative === '' || str_contains($relative, '..')) {
+      $this->logger->warning('Rejected unsafe mail module logo path: @path', [
+        '@path' => $relative,
+      ]);
+      return '';
+    }
     $modulePath = 'modules/contrib/markaspot/modules/markaspot_mail';
     if ($this->moduleExtensionList !== NULL) {
       try {
@@ -791,7 +799,14 @@ class MailBrandingService {
         ]);
       }
     }
-    return $this->ensureAbsolute('/' . $modulePath . '/' . $relative) ?? ('/' . $modulePath . '/' . $relative);
+    $rootRelative = '/' . $modulePath . '/' . $relative;
+    if (defined('DRUPAL_ROOT') && !is_readable(DRUPAL_ROOT . $rootRelative)) {
+      $this->logger->warning('Mail module logo path is not readable: @path', [
+        '@path' => $rootRelative,
+      ]);
+      return '';
+    }
+    return $rootRelative;
   }
 
   /**

--- a/modules/markaspot_mail/src/Service/MailBrandingService.php
+++ b/modules/markaspot_mail/src/Service/MailBrandingService.php
@@ -9,6 +9,7 @@ use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Extension\ModuleExtensionList;
+use Drupal\Core\File\FileSystemInterface;
 use Drupal\Core\File\FileUrlGeneratorInterface;
 use Drupal\Core\Language\LanguageManagerInterface;
 use Drupal\Core\Render\Markup;
@@ -107,6 +108,7 @@ class MailBrandingService {
     private readonly LoggerInterface $logger,
     private readonly ?ModuleExtensionList $moduleExtensionList = NULL,
     private readonly ?RequestStack $requestStack = NULL,
+    private readonly ?FileSystemInterface $fileSystem = NULL,
   ) {}
 
   /**
@@ -239,18 +241,26 @@ class MailBrandingService {
     // Logo: prefer field_logo_light; absolute URL via FileUrlGenerator.
     // SVG files are additionally inlined for email client compatibility —
     // Gmail, Outlook and iOS Mail all block SVG in <img src="...svg">.
+    $resolvedJurisdictionLogo = FALSE;
     if ($group->hasField('field_logo_light') && !$group->get('field_logo_light')->isEmpty()) {
       $logoField = $group->get('field_logo_light');
-      $logoUrl = $this->resolveFileAbsoluteUrl($logoField);
-      if ($logoUrl !== NULL) {
-        $branding['logo_url'] = $logoUrl;
-        $entity = $logoField->entity;
-        if ($entity !== NULL) {
-          $svgInline = $this->readSvgInline((string) $entity->getFileUri());
-          if ($svgInline !== NULL) {
-            $branding['logo_svg_inline'] = $svgInline;
-          }
-        }
+      $logo = $this->resolveLogoField($logoField);
+      if ($logo !== NULL) {
+        $branding['logo_url'] = $logo['url'];
+        $branding['logo_svg_inline'] = $logo['svg_inline'];
+        $resolvedJurisdictionLogo = TRUE;
+      }
+    }
+
+    // Some tenants keep their logo source in field_nuxt_config only because
+    // the shared frontend uses theme.logos.light/dark as its brand contract.
+    // Reuse that source for transactional mails when the image field is not
+    // populated, so self-hosted tenants do not fall back to the platform logo.
+    if (!$resolvedJurisdictionLogo && $group->hasField('field_nuxt_config') && !$group->get('field_nuxt_config')->isEmpty()) {
+      $logo = $this->resolveLogoFromNuxtConfig((string) $group->get('field_nuxt_config')->value);
+      if ($logo !== NULL) {
+        $branding['logo_url'] = $logo['url'];
+        $branding['logo_svg_inline'] = $logo['svg_inline'];
       }
     }
 
@@ -437,17 +447,12 @@ class MailBrandingService {
   }
 
   /**
-   * Absolute URL for a file-reference item (field_logo_light etc.).
+   * Resolves a file-reference logo to a mail-safe logo package.
    *
-   * Mails are often rendered outside an HTTP request (queue workers, cron,
-   * CLI). In that context FileUrlGenerator::generateAbsoluteString() falls
-   * back to the global $base_url from settings.php, which on multi-tenant
-   * cloud deployments points at the wrong host or at localhost. We defend
-   * against that: if the resolved URL is not an absolute HTTP URL, prepend
-   * an explicitly configured platform.backend_base_url so inbox clients
-   * can actually fetch the asset.
+   * @return array{url: string, svg_inline: MarkupInterface|null}|null
+   *   A resolved logo package, or NULL when the file reference is unusable.
    */
-  private function resolveFileAbsoluteUrl($fieldItemList): ?string {
+  private function resolveLogoField($fieldItemList): ?array {
     try {
       $entity = $fieldItemList->entity;
       if ($entity === NULL) {
@@ -457,8 +462,16 @@ class MailBrandingService {
       if ($uri === '') {
         return NULL;
       }
-      $url = (string) $this->fileUrlGenerator->generateAbsoluteString($uri);
-      return $this->ensureAbsolute($url);
+      $mailUri = $this->preferRasterLogoUri($uri);
+      $url = $this->ensureAbsolute((string) $this->fileUrlGenerator->generateAbsoluteString($mailUri));
+      if ($url === NULL) {
+        return NULL;
+      }
+
+      return [
+        'url' => $url,
+        'svg_inline' => $mailUri === $uri ? $this->readSvgInline($uri) : NULL,
+      ];
     }
     catch (\Throwable $e) {
       $this->logger->warning('Could not resolve absolute URL for jurisdiction logo: @msg', [
@@ -541,7 +554,11 @@ class MailBrandingService {
       ->get('markaspot_mail.settings')
       ->get('platform.backend_base_url') ?? '');
     if ($configured !== '') {
-      return $configured;
+      $validated = $this->validateHttpUrl($configured, '');
+      if ($validated !== '') {
+        return rtrim($validated, '/');
+      }
+      $this->logger->warning('Ignored invalid mail backend base URL from markaspot_mail.settings.platform.backend_base_url.');
     }
     if ($this->requestStack !== NULL) {
       $request = $this->requestStack->getCurrentRequest();
@@ -589,6 +606,133 @@ class MailBrandingService {
       return NULL;
     }
     return $this->normalizeColor($raw, self::DEFAULT_PRIMARY);
+  }
+
+  /**
+   * Resolves the light logo from field_nuxt_config JSON.
+   *
+   * Tenants often already publish their frontend brand assets through
+   * theme.logos.light. Accept the same admin-managed contract for mail, but
+   * keep the resolver narrow: public files only. External http(s) URLs are
+   * intentionally ignored here so citizen mail does not embed arbitrary
+   * remote tracking pixels as tenant logos.
+   *
+   * @return array{url: string, svg_inline: MarkupInterface|null}|null
+   *   A resolved logo package, or NULL when no safe logo reference exists.
+   */
+  private function resolveLogoFromNuxtConfig(string $json): ?array {
+    $decoded = json_decode($json, TRUE);
+    if (!is_array($decoded)) {
+      return NULL;
+    }
+    $raw = $decoded['theme']['logos']['light'] ?? NULL;
+    if (!is_string($raw) || trim($raw) === '') {
+      return NULL;
+    }
+    return $this->resolveLogoReference(trim($raw));
+  }
+
+  /**
+   * Resolves an admin-managed logo reference to a mail-safe URL.
+   *
+   * @return array{url: string, svg_inline: MarkupInterface|null}|null
+   *   A resolved logo package, or NULL when the reference is unusable.
+   */
+  private function resolveLogoReference(string $raw): ?array {
+    if (preg_match('/[\r\n\0]/', $raw) === 1) {
+      $this->logger->warning('Rejected unsafe jurisdiction mail logo reference containing control bytes.');
+      return NULL;
+    }
+
+    if (preg_match('#^https?://#i', $raw) === 1) {
+      $this->logger->warning('Rejected external jurisdiction mail logo reference from frontend config.');
+      return NULL;
+    }
+
+    $uri = $this->publicFileUriFromLogoReference($raw);
+    if ($uri === NULL) {
+      $this->logger->warning('Rejected unsupported jurisdiction mail logo reference: @path', [
+        '@path' => $raw,
+      ]);
+      return NULL;
+    }
+
+    $mailUri = $this->preferRasterLogoUri($uri);
+
+    try {
+      $url = $this->ensureAbsolute((string) $this->fileUrlGenerator->generateAbsoluteString($mailUri));
+    }
+    catch (\Throwable $e) {
+      $this->logger->warning('Could not resolve jurisdiction mail logo from config: @msg', [
+        '@msg' => $e->getMessage(),
+      ]);
+      return NULL;
+    }
+    if ($url === NULL) {
+      return NULL;
+    }
+
+    return [
+      'url' => $url,
+      'svg_inline' => $mailUri === $uri ? $this->readSvgInline($uri) : NULL,
+    ];
+  }
+
+  /**
+   * Prefers a sibling PNG for SVG public-file logos.
+   */
+  private function preferRasterLogoUri(string $uri): string {
+    if (preg_match('/\.svg$/i', $uri) !== 1) {
+      return $uri;
+    }
+    $candidate = (string) preg_replace('/\.svg$/i', '.png', $uri);
+    return $this->fileExists($candidate) ? $candidate : $uri;
+  }
+
+  /**
+   * Checks file existence without triggering warnings for unresolved wrappers.
+   */
+  private function fileExists(string $uri): bool {
+    if (preg_match('/^[a-z][a-z0-9+.-]*:\/\//i', $uri) === 1) {
+      $realpath = $this->fileSystem?->realpath($uri);
+      return is_string($realpath) && $realpath !== '' && is_readable($realpath);
+    }
+
+    return is_readable($uri);
+  }
+
+  /**
+   * Maps a frontend public-files logo path to a Drupal stream wrapper URI.
+   */
+  private function publicFileUriFromLogoReference(string $raw): ?string {
+    $raw = str_replace('\\', '/', trim($raw));
+    if ($raw === '') {
+      return NULL;
+    }
+
+    if (str_starts_with($raw, 'public://')) {
+      $relative = substr($raw, strlen('public://'));
+    }
+    else {
+      $path = parse_url($raw, PHP_URL_PATH);
+      $path = is_string($path) && $path !== '' ? $path : $raw;
+      if (str_starts_with($path, '/sites/default/files/')) {
+        $relative = substr($path, strlen('/sites/default/files/'));
+      }
+      elseif (str_starts_with($path, 'sites/default/files/')) {
+        $relative = substr($path, strlen('sites/default/files/'));
+      }
+      else {
+        return NULL;
+      }
+    }
+
+    $relative = ltrim($relative, '/');
+    if ($relative === '' || str_contains($relative, '..')) {
+      return NULL;
+    }
+
+    return 'public://' . $relative;
   }
 
   /**
@@ -742,7 +886,7 @@ class MailBrandingService {
     // precedence on supporting clients.
     $clean = (string) preg_replace(
       '/<svg\b/i',
-      '<svg width="96" style="display:block; max-width:96px; height:auto; border:0; outline:none;"',
+      '<svg width="160" style="display:block; max-width:160px; height:auto; border:0; outline:none;"',
       $clean,
       1,
     );

--- a/modules/markaspot_mail/src/Service/MailHtmlRenderer.php
+++ b/modules/markaspot_mail/src/Service/MailHtmlRenderer.php
@@ -136,13 +136,13 @@ class MailHtmlRenderer {
       }
       $intro = trim((string) ($content['intro'] ?? ''));
       if ($intro !== '') {
-        $lines[] = $intro;
+        $lines[] = $this->mailHtmlFragmentToPlain($intro);
         $lines[] = '';
       }
       foreach ((array) ($content['body_blocks'] ?? []) as $block) {
         $block = trim((string) $block);
         if ($block !== '') {
-          $lines[] = $block;
+          $lines[] = $this->mailHtmlFragmentToPlain($block);
           $lines[] = '';
         }
       }
@@ -195,6 +195,25 @@ class MailHtmlRenderer {
     // Collapse 3+ consecutive newlines to two.
     $text = (string) preg_replace("/\n{3,}/", "\n\n", $text);
     return trim($text) . "\n";
+  }
+
+  /**
+   * Converts a sanitized mail fragment back to plain text.
+   *
+   * Body blocks may be MarkupInterface values containing mail-safe tags
+   * such as <br>, <p> or lists. Keep the derived text/plain alternative
+   * readable instead of leaking literal tags into MIME clients.
+   */
+  private function mailHtmlFragmentToPlain(string $html): string {
+    $text = (string) preg_replace('#<br\s*/?>#i', "\n", $html);
+    $text = (string) preg_replace('#</(p|li|h2|h3)>#i', "\n", $text);
+    $text = (string) preg_replace('#<(ul|ol)[^>]*>#i', "\n", $text);
+    $text = (string) preg_replace('#</(ul|ol)>#i', "\n", $text);
+    $text = strip_tags($text);
+    $text = html_entity_decode($text, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+    $text = (string) preg_replace("/[ \t]+\n/", "\n", $text);
+    $text = (string) preg_replace("/\n{3,}/", "\n\n", $text);
+    return trim($text);
   }
 
   /**

--- a/modules/markaspot_mail/templates/mail-hero-code.html.twig
+++ b/modules/markaspot_mail/templates/mail-hero-code.html.twig
@@ -26,10 +26,10 @@
   </tr>
   <tr>
     <td align="center" style="padding:0;">
-      <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color:{{ branding.primary_color }}; border-radius:20px;">
+      <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color:{{ branding.primary_color }}; border-radius:16px;">
         <tr>
-          <td align="center" style="padding:40px 80px;">
-            <div style="font-family:'SF Mono',Monaco,Menlo,monospace; font-size:40px; line-height:48px; letter-spacing:0.2em; color:#ffffff; font-weight:600;">
+          <td align="center" style="padding:28px 36px;">
+            <div style="font-family:'SF Mono',Monaco,Menlo,monospace; font-size:34px; line-height:42px; letter-spacing:0.12em; color:#ffffff; font-weight:600;">
               {% if content.code|length == 6 %}
                 <span>{{ content.code|slice(0,3) }}</span><span style="margin-left:8px;">{{ content.code|slice(3) }}</span>
               {% else %}

--- a/modules/markaspot_mail/templates/mail-layout.html.twig
+++ b/modules/markaspot_mail/templates/mail-layout.html.twig
@@ -54,7 +54,7 @@
 <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color:{{ branding.background_color }};">
   <tr>
     <td align="center" style="padding:32px 16px;">
-      <table role="presentation" class="mas-container" width="560" cellpadding="0" cellspacing="0" border="0" style="width:560px; max-width:560px;">
+      <table role="presentation" class="mas-container" width="100%" cellpadding="0" cellspacing="0" border="0" style="width:100%; max-width:560px;">
 
         {# Logo row. In platform mode we only render the MaS inline SVG
            when branding.platform_footer is set; otherwise we fall through
@@ -69,7 +69,7 @@
             {% elseif branding.logo_svg_inline %}
               {{ branding.logo_svg_inline }}
             {% elseif branding.logo_url %}
-              <img src="{{ branding.logo_url }}" alt="{{ branding.platform_name }}" width="96" style="display:block; max-width:96px; height:auto; border:0; outline:none; text-decoration:none;">
+              <img src="{{ branding.logo_url }}" alt="{{ branding.platform_name }}" width="160" style="display:block; max-width:160px; height:auto; border:0; outline:none; text-decoration:none;">
             {% else %}
               <div style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif; font-size:18px; font-weight:600; color:#111827;">
                 {{ branding.platform_name }}

--- a/modules/markaspot_mail/tests/src/Unit/Builder/EcaActionEmailBuilderTest.php
+++ b/modules/markaspot_mail/tests/src/Unit/Builder/EcaActionEmailBuilderTest.php
@@ -133,6 +133,55 @@ final class EcaActionEmailBuilderTest extends UnitTestCase {
   /**
    *
    */
+  public function testBuildPreservesSingleLineBreaksInsideParagraphs(): void {
+    $builder = $this->buildBuilder();
+    $body = "Address:\nOstwall 175\n47798 Krefeld\n\nFooter:\nLine one\nLine two";
+
+    $ctx = new MailContext(
+      module: 'system',
+      key: 'action_send_email',
+      langcode: 'en',
+      params: ['context' => ['subject' => 'tokenized-template', 'message' => 'tokenized-template']],
+      to: 'staff@example.com',
+      subject: 'Forwarded report',
+      body: [$body],
+    );
+    $msg = $builder->build($ctx);
+
+    $this->assertNotNull($msg);
+    $this->assertSame('Address:<br>Ostwall 175<br>47798 Krefeld', (string) $msg->content['intro']);
+    $this->assertSame('Footer:<br>Line one<br>Line two', (string) $msg->content['body_blocks'][0]);
+  }
+
+  /**
+   *
+   */
+  public function testBuildLeavesStructuredHtmlBlocksUntouched(): void {
+    $builder = $this->buildBuilder();
+    $body = "Intro\nline\n\n<ul>\n<li>One</li>\n<li>Two</li>\n</ul>\n\nLine one<br>\nLine two";
+
+    $ctx = new MailContext(
+      module: 'system',
+      key: 'action_send_email',
+      langcode: 'en',
+      params: ['context' => ['subject' => 'tokenized-template', 'message' => 'tokenized-template']],
+      to: 'staff@example.com',
+      subject: 'Forwarded report',
+      body: [$body],
+    );
+    $msg = $builder->build($ctx);
+
+    $this->assertNotNull($msg);
+    $this->assertSame('Intro<br>line', (string) $msg->content['intro']);
+    $this->assertStringContainsString("<ul>\n<li>One</li>\n<li>Two</li>\n</ul>", (string) $msg->content['body_blocks'][0]);
+    $this->assertStringNotContainsString('<ul><br>', (string) $msg->content['body_blocks'][0]);
+    $this->assertSame("Line one<br>\nLine two", (string) $msg->content['body_blocks'][1]);
+    $this->assertStringNotContainsString('<br><br>', (string) $msg->content['body_blocks'][1]);
+  }
+
+  /**
+   *
+   */
   public function testBuildResolvesJurisdictionModeFromNodeContext(): void {
     $group = $this->createMock(GroupInterface::class);
     $group->method('getEntityTypeId')->willReturn('group');

--- a/modules/markaspot_mail/tests/src/Unit/Builder/PasswordlessOtpBuilderTest.php
+++ b/modules/markaspot_mail/tests/src/Unit/Builder/PasswordlessOtpBuilderTest.php
@@ -200,6 +200,112 @@ final class PasswordlessOtpBuilderTest extends UnitTestCase {
   }
 
   /**
+   * Configured content templates override the built-in OTP fallback copy.
+   */
+  public function testBuildAppliesConfigContentTemplates(): void {
+    $config = $this->createMock(ImmutableConfig::class);
+    $config->method('get')->willReturnCallback(
+      fn (string $key): ?array => $key === 'verification_code'
+        ? [
+          'subject' => '@platform_name: Ihr Bestätigungscode',
+          'preheader' => 'Ihr Bestätigungscode ist @minutes Minuten gültig.',
+          'headline' => 'Konto bestätigen',
+          'subtext' => 'Geben Sie diesen Code innerhalb der nächsten @minutes Minuten ein.',
+          'plain_text' => "Ihr Bestätigungscode: @code\n\nEr läuft in @minutes Minuten ab.",
+        ]
+        : NULL,
+    );
+    $configFactory = $this->createMock(ConfigFactoryInterface::class);
+    $configFactory->method('get')->willReturn($config);
+
+    $override = $this->createMock(LanguageConfigOverride::class);
+    $override->method('get')->willReturn(NULL);
+    $languageManager = $this->createMock(ConfigurableLanguageManagerInterface::class);
+    $languageManager->method('getLanguageConfigOverride')->willReturn($override);
+
+    $builder = $this->buildBuilder(
+      configFactory: $configFactory,
+      languageManager: $languageManager,
+    );
+    $ctx = new MailContext(
+      module: 'markaspot_passwordless',
+      key: 'verification_code',
+      langcode: 'de',
+      params: [
+        'code' => '156428',
+        'expires_in' => '10',
+        'platform_name' => 'Maak et, Krefeld!',
+      ],
+      to: 'user@example.com',
+    );
+    $msg = $builder->build($ctx);
+
+    $this->assertNotNull($msg);
+    $this->assertSame('Maak et, Krefeld!: Ihr Bestätigungscode', $msg->subject);
+    $this->assertSame('Ihr Bestätigungscode ist 10 Minuten gültig.', $msg->content['preheader']);
+    $this->assertSame('Konto bestätigen', $msg->content['headline']);
+    $this->assertSame('Geben Sie diesen Code innerhalb der nächsten 10 Minuten ein.', $msg->content['subtext']);
+    $this->assertSame("Ihr Bestätigungscode: 156428\n\nEr läuft in 10 Minuten ab.", $msg->plainText);
+  }
+
+  /**
+   * Legacy locale overrides stay localized when newer content keys are absent.
+   */
+  public function testBuildDerivesLocalizedContentFromLegacyBodyOverride(): void {
+    $config = $this->createMock(ImmutableConfig::class);
+    $config->method('get')->willReturnCallback(
+      fn (string $key): ?array => $key === 'verification_code'
+        ? [
+          'subject' => '@platform_name: Your verification code',
+          'preheader' => 'Your verification code expires in @minutes minutes.',
+          'headline' => 'Verify your account',
+          'subtext' => 'Enter this code in the next @minutes minutes.',
+          'plain_text' => "Your verification code: @code\n\nIt expires in @minutes minutes.",
+        ]
+        : NULL,
+    );
+    $configFactory = $this->createMock(ConfigFactoryInterface::class);
+    $configFactory->method('get')->willReturn($config);
+
+    $override = $this->createMock(LanguageConfigOverride::class);
+    $override->method('get')->willReturnCallback(
+      fn (string $key): ?array => $key === 'verification_code'
+        ? [
+          'subject' => '@platform_name: Ověřovací kód',
+          'body' => "Váš ověřovací kód je: @code\n\nTento kód vyprší za @expires_in minut.\n\nPokud jste o něj nežádali, můžete tento e-mail ignorovat.\n",
+        ]
+        : NULL,
+    );
+    $languageManager = $this->createMock(ConfigurableLanguageManagerInterface::class);
+    $languageManager->method('getLanguageConfigOverride')->willReturn($override);
+
+    $builder = $this->buildBuilder(
+      configFactory: $configFactory,
+      languageManager: $languageManager,
+    );
+    $ctx = new MailContext(
+      module: 'markaspot_passwordless',
+      key: 'verification_code',
+      langcode: 'cs',
+      params: [
+        'code' => '156428',
+        'expires_in' => '10',
+        'platform_name' => 'CivicSpot',
+      ],
+      to: 'user@example.com',
+    );
+    $msg = $builder->build($ctx);
+
+    $this->assertNotNull($msg);
+    $this->assertSame('CivicSpot: Ověřovací kód', $msg->subject);
+    $this->assertSame('Ověřovací kód', $msg->content['headline']);
+    $this->assertSame('Tento kód vyprší za 10 minut.', $msg->content['preheader']);
+    $this->assertStringContainsString('Pokud jste o něj nežádali', $msg->content['subtext']);
+    $this->assertStringContainsString('Váš ověřovací kód je: 156428', $msg->plainText);
+    $this->assertStringNotContainsString('Your verification code', $msg->plainText);
+  }
+
+  /**
    * Builds a MailContext with sensible test defaults.
    */
   private function buildContext(array $params): MailContext {

--- a/modules/markaspot_mail/tests/src/Unit/MailBrandingServiceTest.php
+++ b/modules/markaspot_mail/tests/src/Unit/MailBrandingServiceTest.php
@@ -13,6 +13,7 @@ use Drupal\Core\Config\ImmutableConfig;
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Extension\ModuleExtensionList;
 use Drupal\Core\File\FileUrlGeneratorInterface;
 use Drupal\Core\Language\LanguageManagerInterface;
 use Drupal\Core\Site\Settings;
@@ -82,6 +83,82 @@ final class MailBrandingServiceTest extends UnitTestCase {
     $this->assertSame('https://mark-a-spot.com', $branding['platform_footer']['mas_link']);
     $this->assertSame('https://civicspot.io', $branding['platform_footer']['civicspot_link']);
     $this->assertStringContainsString('Civic Patches GmbH', $branding['platform_footer']['copyright']);
+  }
+
+  /**
+   * Module-local logos stay relative so PHPMailer embeds them as cid images.
+   */
+  public function testModuleLogoPathStaysRelativeForPhpmailerEmbedding(): void {
+    $overrides = self::PLATFORM_SETTINGS;
+    $overrides['platform.backend_base_url'] = 'https://management.example.test';
+    $moduleList = $this->createMock(ModuleExtensionList::class);
+    $moduleList->method('getPath')
+      ->with('markaspot_mail')
+      ->willReturn('profiles/contrib/markaspot/modules/markaspot_mail');
+
+    $service = $this->buildService(
+      NULL,
+      NULL,
+      NULL,
+      $overrides,
+      $moduleList,
+    );
+    $branding = $service->getBranding(NULL, 'platform', 'en');
+
+    $this->assertSame(
+      '/profiles/contrib/markaspot/modules/markaspot_mail/images/mark-a-spot-logo@2x.png',
+      $branding['logo_url'],
+    );
+  }
+
+  /**
+   * Missing module-local logos fall back to text instead of breaking mail.
+   */
+  public function testMissingModuleLogoPathFallsBackToTextLogo(): void {
+    $overrides = self::PLATFORM_SETTINGS;
+    $overrides['platform.logo_path'] = 'images/does-not-exist.png';
+    $moduleList = $this->createMock(ModuleExtensionList::class);
+    $moduleList->method('getPath')
+      ->with('markaspot_mail')
+      ->willReturn('profiles/contrib/markaspot/modules/markaspot_mail');
+
+    $service = $this->buildService(
+      NULL,
+      NULL,
+      NULL,
+      $overrides,
+      $moduleList,
+    );
+    $branding = $service->getBranding(NULL, 'platform', 'en');
+
+    $this->assertSame('', $branding['logo_url']);
+  }
+
+  /**
+   * Relative logo paths may not traverse outside the mail module assets.
+   */
+  public function testTraversalModuleLogoPathIsRejected(): void {
+    $overrides = self::PLATFORM_SETTINGS;
+    $overrides['platform.logo_path'] = '../settings.php';
+    $service = $this->buildService(NULL, NULL, NULL, $overrides);
+
+    $branding = $service->getBranding(NULL, 'platform', 'en');
+
+    $this->assertSame('', $branding['logo_url']);
+  }
+
+  /**
+   * Absolute operator-configured logo URLs still pass through as URLs.
+   */
+  public function testAbsoluteLogoPathStillPassesThrough(): void {
+    $overrides = self::PLATFORM_SETTINGS;
+    $overrides['platform.logo_path'] = 'https://assets.example.test/logo.png';
+    $overrides['platform.backend_base_url'] = 'https://management.example.test';
+    $service = $this->buildService(NULL, NULL, NULL, $overrides);
+
+    $branding = $service->getBranding(NULL, 'platform', 'en');
+
+    $this->assertSame('https://assets.example.test/logo.png', $branding['logo_url']);
   }
 
   /**
@@ -305,8 +382,8 @@ final class MailBrandingServiceTest extends UnitTestCase {
   /**
    * Tests disabling the optional platform footer attribution.
    *
-   * Self-hosted enterprise installations opt out so no civicpatches.de/impressum
-   * or copyright line ships in their mails.
+   * Self-hosted enterprise installations opt out so no civicpatches.de
+   * impressum or copyright line ships in their mails.
    */
   public function testShowPlatformFooterFalseSuppressesPlatformFooter(): void {
     $overrides = self::PLATFORM_SETTINGS;
@@ -413,8 +490,9 @@ final class MailBrandingServiceTest extends UnitTestCase {
   /**
    * Tests legal URL suppression when self-hosted frontend bases are empty.
    *
-   * A self-hosted jurisdiction with non-URL legal content, empty tenant template
-   * and empty platform frontend_base_url must not produce a path-only URL.
+   * A self-hosted jurisdiction with non-URL legal content, empty tenant
+   * template and empty platform frontend_base_url must not produce a
+   * path-only URL.
    */
   public function testSelfHostedSlugLegalUrlSuppressedWhenNoFrontendBase(): void {
     // setUp() resets Settings to empty -> default self_hosted.
@@ -457,6 +535,7 @@ final class MailBrandingServiceTest extends UnitTestCase {
     ?EntityStorageInterface $storage = NULL,
     ?LoggerInterface $logger = NULL,
     ?array $settingsOverride = NULL,
+    ?ModuleExtensionList $moduleExtensionList = NULL,
   ): MailBrandingService {
     $storage = $storage ?? $this->createMock(EntityStorageInterface::class);
     if ($group !== NULL) {
@@ -493,6 +572,7 @@ final class MailBrandingServiceTest extends UnitTestCase {
       $languageManager,
       $fileUrlGenerator,
       $logger,
+      $moduleExtensionList,
     );
   }
 

--- a/modules/markaspot_mail/tests/src/Unit/MailBrandingServiceTest.php
+++ b/modules/markaspot_mail/tests/src/Unit/MailBrandingServiceTest.php
@@ -14,6 +14,7 @@ use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Extension\ModuleExtensionList;
+use Drupal\Core\File\FileSystemInterface;
 use Drupal\Core\File\FileUrlGeneratorInterface;
 use Drupal\Core\Language\LanguageManagerInterface;
 use Drupal\Core\Site\Settings;
@@ -159,6 +160,242 @@ final class MailBrandingServiceTest extends UnitTestCase {
     $branding = $service->getBranding(NULL, 'platform', 'en');
 
     $this->assertSame('https://assets.example.test/logo.png', $branding['logo_url']);
+  }
+
+  /**
+   * Jurisdiction mails fall back to the frontend logo contract.
+   */
+  public function testJurisdictionLogoFallsBackToNuxtConfigPublicFile(): void {
+    $group = $this->buildGroup([
+      'id' => 1,
+      'label' => 'KBK Krefeld',
+      'field_slug' => 'krefeld',
+      'field_platform_name' => 'Maak et, Krefeld!',
+      'field_logo_light' => '',
+      'field_nuxt_config' => json_encode([
+        'theme' => [
+          'primary' => '#276327',
+          'logos' => [
+            'light' => '/sites/default/files/logos/kbk-logo-light.svg',
+          ],
+        ],
+      ]),
+    ]);
+    $overrides = self::PLATFORM_SETTINGS;
+    $overrides['platform.backend_base_url'] = 'https://management.example.test';
+    $fileUrlGenerator = $this->createMock(FileUrlGeneratorInterface::class);
+    $fileUrlGenerator->expects($this->once())
+      ->method('generateAbsoluteString')
+      ->with('public://logos/kbk-logo-light.svg')
+      ->willReturn('http://cloud-drupal/sites/default/files/logos/kbk-logo-light.svg');
+    $fileSystem = $this->createMock(FileSystemInterface::class);
+    $fileSystem->expects($this->once())
+      ->method('realpath')
+      ->with('public://logos/kbk-logo-light.png')
+      ->willReturn(FALSE);
+
+    $service = $this->buildService(
+      $group,
+      NULL,
+      NULL,
+      $overrides,
+      NULL,
+      $fileUrlGenerator,
+      $fileSystem,
+    );
+
+    $branding = $service->getBranding(1, 'jurisdiction', 'en');
+
+    $this->assertSame(
+      'https://management.example.test/sites/default/files/logos/kbk-logo-light.svg',
+      $branding['logo_url'],
+    );
+    $this->assertNull($branding['logo_svg_inline']);
+  }
+
+  /**
+   * Jurisdiction field SVG logos prefer their stored PNG mail fallback.
+   */
+  public function testJurisdictionFieldLogoPrefersSiblingPngForSvg(): void {
+    $group = $this->buildGroup([
+      'id' => 1,
+      'label' => 'KBK Krefeld',
+      'field_slug' => 'krefeld',
+      'field_platform_name' => 'Maak et, Krefeld!',
+      'field_logo_light' => ['uri' => 'public://jurisdictions/1/logos/kbk-logo-light.svg'],
+    ]);
+    $overrides = self::PLATFORM_SETTINGS;
+    $overrides['platform.backend_base_url'] = 'https://management.example.test';
+    $fileUrlGenerator = $this->createMock(FileUrlGeneratorInterface::class);
+    $fileUrlGenerator->expects($this->once())
+      ->method('generateAbsoluteString')
+      ->with('public://jurisdictions/1/logos/kbk-logo-light.png')
+      ->willReturn('http://cloud-drupal/sites/default/files/jurisdictions/1/logos/kbk-logo-light.png');
+    $fileSystem = $this->createMock(FileSystemInterface::class);
+    $fileSystem->expects($this->once())
+      ->method('realpath')
+      ->with('public://jurisdictions/1/logos/kbk-logo-light.png')
+      ->willReturn(__FILE__);
+
+    $service = $this->buildService(
+      $group,
+      NULL,
+      NULL,
+      $overrides,
+      NULL,
+      $fileUrlGenerator,
+      $fileSystem,
+    );
+
+    $branding = $service->getBranding(1, 'jurisdiction', 'en');
+
+    $this->assertSame(
+      'https://management.example.test/sites/default/files/jurisdictions/1/logos/kbk-logo-light.png',
+      $branding['logo_url'],
+    );
+    $this->assertNull($branding['logo_svg_inline']);
+  }
+
+  /**
+   * SVG frontend logos prefer a sibling PNG when one is available.
+   */
+  public function testJurisdictionLogoPrefersSiblingPngForNuxtConfigSvg(): void {
+    $group = $this->buildGroup([
+      'id' => 1,
+      'label' => 'KBK Krefeld',
+      'field_slug' => 'krefeld',
+      'field_platform_name' => 'Maak et, Krefeld!',
+      'field_logo_light' => '',
+      'field_nuxt_config' => json_encode([
+        'theme' => [
+          'logos' => [
+            'light' => 'public://logos/kbk-logo-light.svg',
+          ],
+        ],
+      ]),
+    ]);
+    $overrides = self::PLATFORM_SETTINGS;
+    $overrides['platform.backend_base_url'] = 'https://management.example.test';
+    $fileUrlGenerator = $this->createMock(FileUrlGeneratorInterface::class);
+    $fileUrlGenerator->expects($this->once())
+      ->method('generateAbsoluteString')
+      ->with('public://logos/kbk-logo-light.png')
+      ->willReturn('http://cloud-drupal/sites/default/files/logos/kbk-logo-light.png');
+    $fileSystem = $this->createMock(FileSystemInterface::class);
+    $fileSystem->expects($this->once())
+      ->method('realpath')
+      ->with('public://logos/kbk-logo-light.png')
+      ->willReturn(__FILE__);
+
+    $service = $this->buildService(
+      $group,
+      NULL,
+      NULL,
+      $overrides,
+      NULL,
+      $fileUrlGenerator,
+      $fileSystem,
+    );
+
+    $branding = $service->getBranding(1, 'jurisdiction', 'en');
+
+    $this->assertSame(
+      'https://management.example.test/sites/default/files/logos/kbk-logo-light.png',
+      $branding['logo_url'],
+    );
+    $this->assertNull($branding['logo_svg_inline']);
+  }
+
+  /**
+   * External frontend logo references are ignored for citizen mails.
+   */
+  public function testJurisdictionLogoRejectsExternalNuxtConfigReference(): void {
+    $group = $this->buildGroup([
+      'id' => 1,
+      'label' => 'KBK Krefeld',
+      'field_slug' => 'krefeld',
+      'field_platform_name' => 'Maak et, Krefeld!',
+      'field_logo_light' => '',
+      'field_nuxt_config' => json_encode([
+        'theme' => [
+          'logos' => [
+            'light' => 'https://tracking.example.test/logo.png',
+          ],
+        ],
+      ]),
+    ]);
+    $logger = $this->createMock(LoggerInterface::class);
+    $logger->expects($this->atLeastOnce())
+      ->method('warning');
+    $fileUrlGenerator = $this->createMock(FileUrlGeneratorInterface::class);
+    $fileUrlGenerator->expects($this->never())
+      ->method('generateAbsoluteString');
+    $moduleList = $this->createMock(ModuleExtensionList::class);
+    $moduleList->method('getPath')
+      ->with('markaspot_mail')
+      ->willReturn('profiles/contrib/markaspot/modules/markaspot_mail');
+
+    $service = $this->buildService(
+      $group,
+      NULL,
+      $logger,
+      self::PLATFORM_SETTINGS,
+      $moduleList,
+      $fileUrlGenerator,
+    );
+
+    $branding = $service->getBranding(1, 'jurisdiction', 'en');
+
+    $this->assertSame(
+      '/profiles/contrib/markaspot/modules/markaspot_mail/images/mark-a-spot-logo@2x.png',
+      $branding['logo_url'],
+    );
+  }
+
+  /**
+   * Unsafe frontend logo references are ignored.
+   */
+  public function testJurisdictionLogoRejectsUnsupportedNuxtConfigReference(): void {
+    $group = $this->buildGroup([
+      'id' => 1,
+      'label' => 'KBK Krefeld',
+      'field_slug' => 'krefeld',
+      'field_platform_name' => 'Maak et, Krefeld!',
+      'field_logo_light' => '',
+      'field_nuxt_config' => json_encode([
+        'theme' => [
+          'logos' => [
+            'light' => 'private://secret.svg',
+          ],
+        ],
+      ]),
+    ]);
+    $logger = $this->createMock(LoggerInterface::class);
+    $logger->expects($this->atLeastOnce())
+      ->method('warning');
+    $fileUrlGenerator = $this->createMock(FileUrlGeneratorInterface::class);
+    $fileUrlGenerator->expects($this->never())
+      ->method('generateAbsoluteString');
+    $moduleList = $this->createMock(ModuleExtensionList::class);
+    $moduleList->method('getPath')
+      ->with('markaspot_mail')
+      ->willReturn('profiles/contrib/markaspot/modules/markaspot_mail');
+
+    $service = $this->buildService(
+      $group,
+      NULL,
+      $logger,
+      self::PLATFORM_SETTINGS,
+      $moduleList,
+      $fileUrlGenerator,
+    );
+
+    $branding = $service->getBranding(1, 'jurisdiction', 'en');
+
+    $this->assertSame(
+      '/profiles/contrib/markaspot/modules/markaspot_mail/images/mark-a-spot-logo@2x.png',
+      $branding['logo_url'],
+    );
   }
 
   /**
@@ -536,6 +773,8 @@ final class MailBrandingServiceTest extends UnitTestCase {
     ?LoggerInterface $logger = NULL,
     ?array $settingsOverride = NULL,
     ?ModuleExtensionList $moduleExtensionList = NULL,
+    ?FileUrlGeneratorInterface $fileUrlGenerator = NULL,
+    ?FileSystemInterface $fileSystem = NULL,
   ): MailBrandingService {
     $storage = $storage ?? $this->createMock(EntityStorageInterface::class);
     if ($group !== NULL) {
@@ -563,7 +802,7 @@ final class MailBrandingServiceTest extends UnitTestCase {
     ]);
 
     $languageManager = $this->createMock(LanguageManagerInterface::class);
-    $fileUrlGenerator = $this->createMock(FileUrlGeneratorInterface::class);
+    $fileUrlGenerator = $fileUrlGenerator ?? $this->createMock(FileUrlGeneratorInterface::class);
     $logger = $logger ?? $this->createMock(LoggerInterface::class);
 
     return new MailBrandingService(
@@ -573,6 +812,8 @@ final class MailBrandingServiceTest extends UnitTestCase {
       $fileUrlGenerator,
       $logger,
       $moduleExtensionList,
+      NULL,
+      $fileSystem,
     );
   }
 
@@ -635,6 +876,31 @@ final class MailBrandingServiceTest extends UnitTestCase {
       public $entity = NULL;
 
       public function __construct($value) {
+        if (is_array($value) && isset($value['uri'])) {
+          $this->value = $value['uri'];
+          $this->entity = new class ($value['uri']) {
+
+            /**
+             * Referenced file URI.
+             *
+             * @var string
+             */
+            private string $uri;
+
+            public function __construct(string $uri) {
+              $this->uri = $uri;
+            }
+
+            /**
+             * Returns the referenced file URI.
+             */
+            public function getFileUri(): string {
+              return $this->uri;
+            }
+
+          };
+          return;
+        }
         $this->value = $value;
       }
 

--- a/modules/markaspot_mail/tests/src/Unit/MailHtmlRendererTest.php
+++ b/modules/markaspot_mail/tests/src/Unit/MailHtmlRendererTest.php
@@ -95,6 +95,26 @@ final class MailHtmlRendererTest extends UnitTestCase {
     $this->assertStringContainsString('View report: https://mark-a-spot.com/amsterdam/requests/42', $out['plain']);
   }
 
+  public function testCardTransactionalPlainConvertsMailHtmlFragments(): void {
+    $branding = $this->buildBranding();
+    $content = [
+      'headline' => 'Forwarded report',
+      'intro' => Markup::create('Address:<br>Ostwall 175<br>47798 Krefeld'),
+      'body_blocks' => [
+        Markup::create("<ul>\n<li>One</li>\n<li>Two</li>\n</ul>"),
+      ],
+      'preheader' => '',
+    ];
+
+    $renderer = $this->buildRenderer();
+    $plain = $renderer->render('card_transactional', $branding, $content, 'en')['plain'];
+
+    $this->assertStringContainsString("Address:\nOstwall 175\n47798 Krefeld", $plain);
+    $this->assertStringContainsString("One\n\nTwo", $plain);
+    $this->assertStringNotContainsString('<br>', $plain);
+    $this->assertStringNotContainsString('<li>', $plain);
+  }
+
   public function testUnsafeCtaUrlIsFlaggedAsUnsafe(): void {
     $branding = $this->buildBranding();
     $content = [

--- a/modules/markaspot_nuxt/markaspot_nuxt.routing.yml
+++ b/modules/markaspot_nuxt/markaspot_nuxt.routing.yml
@@ -74,6 +74,7 @@ markaspot_nuxt.tenant_settings_logo:
   methods: [POST]
   requirements:
     _custom_access: '\Drupal\markaspot_nuxt\Controller\TenantSettingsController::accessCheck'
+    _csrf_request_header_token: 'TRUE'
     jurisdiction_id: '[a-z0-9_-]+'
   options:
     _format: 'json'
@@ -86,6 +87,7 @@ markaspot_nuxt.tenant_settings_logo_delete:
   methods: [DELETE]
   requirements:
     _custom_access: '\Drupal\markaspot_nuxt\Controller\TenantSettingsController::accessCheck'
+    _csrf_request_header_token: 'TRUE'
     jurisdiction_id: '[a-z0-9_-]+'
   options:
     _format: 'json'
@@ -272,4 +274,3 @@ markaspot_nuxt.content_translation_create:
   options:
     _auth: ['cookie', 'basic_auth', 'api_key_auth']
     _format: 'json'
-

--- a/modules/markaspot_nuxt/src/Controller/TenantSettingsController.php
+++ b/modules/markaspot_nuxt/src/Controller/TenantSettingsController.php
@@ -11,6 +11,7 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\File\FileSystemInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\StreamWrapper\PublicStream;
+use Drupal\Core\StreamWrapper\StreamWrapperManager;
 use Drupal\Core\StreamWrapper\StreamWrapperManagerInterface;
 use Drupal\file\FileRepositoryInterface;
 use Drupal\group\Entity\GroupInterface;
@@ -19,7 +20,9 @@ use Drupal\Component\Utility\EmailValidator;
 use Drupal\markaspot_group\Service\JurisdictionHierarchyResolverInterface;
 use Drupal\markaspot_group\Trait\JurisdictionIdResolverTrait;
 use CommerceGuys\Addressing\Country\CountryRepositoryInterface;
+use enshrined\svgSanitize\Sanitizer;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -440,6 +443,8 @@ class TenantSettingsController extends ControllerBase {
     $uploadedFiles = $request->files;
     $logoLight = $uploadedFiles->get('logo_light');
     $logoDark = $uploadedFiles->get('logo_dark');
+    $logoLightPng = $uploadedFiles->get('logo_light_png');
+    $logoDarkPng = $uploadedFiles->get('logo_dark_png');
 
     if (!$logoLight && !$logoDark) {
       return new JsonResponse(['error' => 'No logo file provided. Use logo_light or logo_dark field.'], 400);
@@ -447,12 +452,20 @@ class TenantSettingsController extends ControllerBase {
 
     $logos = [];
     $errors = [];
+    $warnings = [];
 
     // Process logo_light.
     if ($logoLight) {
-      $result = $this->processLogoUpload($logoLight, $group, 'field_logo_light', 'logo_light');
+      $result = $this->processLogoUpload(
+        $logoLight,
+        $group,
+        'field_logo_light',
+        'logo_light',
+        $logoLightPng instanceof UploadedFile ? $logoLightPng : NULL,
+      );
       if ($result['success']) {
         $logos['light'] = $result['url'];
+        $warnings = array_merge($warnings, $result['warnings'] ?? []);
       }
       else {
         $errors[] = $result['error'];
@@ -461,9 +474,16 @@ class TenantSettingsController extends ControllerBase {
 
     // Process logo_dark.
     if ($logoDark) {
-      $result = $this->processLogoUpload($logoDark, $group, 'field_logo_dark', 'logo_dark');
+      $result = $this->processLogoUpload(
+        $logoDark,
+        $group,
+        'field_logo_dark',
+        'logo_dark',
+        $logoDarkPng instanceof UploadedFile ? $logoDarkPng : NULL,
+      );
       if ($result['success']) {
         $logos['dark'] = $result['url'];
+        $warnings = array_merge($warnings, $result['warnings'] ?? []);
       }
       else {
         $errors[] = $result['error'];
@@ -497,6 +517,9 @@ class TenantSettingsController extends ControllerBase {
     if (!empty($errors)) {
       $response['warnings'] = $errors;
     }
+    if (!empty($warnings)) {
+      $response['warnings'] = array_merge($response['warnings'] ?? [], $warnings);
+    }
 
     $this->getLogger('markaspot_nuxt')->notice(
       'User @user uploaded logo(s) for jurisdiction @id: @logos',
@@ -521,33 +544,24 @@ class TenantSettingsController extends ControllerBase {
    *   The group field name (field_logo_light or field_logo_dark).
    * @param string $fileKey
    *   Human-readable key for error messages (logo_light or logo_dark).
+   * @param \Symfony\Component\HttpFoundation\File\UploadedFile|null $pngFallbackFile
+   *   Optional client-generated PNG fallback for SVG logos.
    *
    * @return array
-   *   Result array with 'success' bool and 'url' or 'error'.
+   *   Result array with 'success' bool, 'url', optional 'warnings', or 'error'.
    */
   protected function processLogoUpload(
-    $uploadedFile,
+    UploadedFile $uploadedFile,
     $group,
     string $fieldName,
     string $fileKey,
+    ?UploadedFile $pngFallbackFile = NULL,
   ): array {
     // Validate file type: only SVG and PNG are allowed.
-    $allowedMimeTypes = ['image/svg+xml', 'image/png'];
     $allowedExtensions = ['svg', 'png'];
-    $mimeType = $uploadedFile->getMimeType();
-    $clientMimeType = $uploadedFile->getClientMimeType();
     $extension = strtolower($uploadedFile->getClientOriginalExtension());
 
-    // SVG files are often detected as application/octet-stream or text/xml
-    // by finfo on temp files. Fall back to client-reported MIME type for SVG
-    // when the extension matches, as an additional safety check.
-    if (!in_array($mimeType, $allowedMimeTypes, TRUE)
-      && in_array($clientMimeType, $allowedMimeTypes, TRUE)
-      && in_array($extension, $allowedExtensions, TRUE)) {
-      $mimeType = $clientMimeType;
-    }
-
-    if (!in_array($mimeType, $allowedMimeTypes, TRUE) || !in_array($extension, $allowedExtensions, TRUE)) {
+    if (!in_array($extension, $allowedExtensions, TRUE)) {
       return [
         'success' => FALSE,
         'error' => "Invalid file type for $fileKey. Only SVG and PNG files are allowed.",
@@ -584,6 +598,7 @@ class TenantSettingsController extends ControllerBase {
     $originalName = $uploadedFile->getClientOriginalName();
     $safeName = preg_replace('/[^a-zA-Z0-9._-]/', '_', $originalName);
     $destination = $uploadDir . '/' . $safeName;
+    $previousFallbackUri = $this->getExistingLogoPngFallbackUri($group, $fieldName);
 
     // Save the file using Drupal's file repository (handles managed files).
     try {
@@ -592,6 +607,22 @@ class TenantSettingsController extends ControllerBase {
         return [
           'success' => FALSE,
           'error' => "Failed to read uploaded file for $fileKey.",
+        ];
+      }
+
+      if ($extension === 'svg') {
+        $fileData = $this->sanitizeSvgLogoData($fileData, $fileKey);
+        if ($fileData === NULL) {
+          return [
+            'success' => FALSE,
+            'error' => "Invalid SVG file for $fileKey.",
+          ];
+        }
+      }
+      elseif (!$this->isPngImageData($fileData)) {
+        return [
+          'success' => FALSE,
+          'error' => "Invalid PNG file for $fileKey.",
         ];
       }
 
@@ -624,26 +655,163 @@ class TenantSettingsController extends ControllerBase {
       ];
     }
 
+    $warnings = [];
+    $mailFallbackUrl = NULL;
+    $mailFallbackUri = NULL;
+    if ($extension === 'svg' && $pngFallbackFile !== NULL) {
+      $fallback = $this->saveLogoPngFallback($pngFallbackFile, $uploadDir, $safeName, $fileKey);
+      if ($fallback['success']) {
+        $mailFallbackUrl = $fallback['url'];
+        $mailFallbackUri = $fallback['uri'] ?? NULL;
+      }
+      else {
+        $warnings[] = $fallback['error'];
+      }
+    }
+
+    if ($previousFallbackUri !== NULL && $previousFallbackUri !== $mailFallbackUri) {
+      $this->deleteFileIfReadable($previousFallbackUri);
+    }
+
     // Assign the file to the group field.
     $group->set($fieldName, ['target_id' => $file->id()]);
 
     // Build the URL for the response (relative path,
     // same pattern as getMarkASpotSettings).
     $uri = $file->getFileUri();
-    $scheme = $this->streamWrapperManager->getScheme($uri);
-    if ($scheme === 'public') {
-      $target = $this->streamWrapperManager->getTarget($uri);
-      $publicPath = PublicStream::basePath();
-      $url = '/' . $publicPath . '/' . $target;
-    }
-    else {
-      $url = '/' . str_replace('://', '/', $uri);
-    }
+    $url = $this->buildPublicFileUrl($uri);
 
     return [
       'success' => TRUE,
       'url' => $url,
+      'mail_fallback_url' => $mailFallbackUrl,
+      'warnings' => $warnings,
     ];
+  }
+
+  /**
+   * Sanitizes uploaded SVG logo data before it is stored publicly.
+   */
+  protected function sanitizeSvgLogoData(string $fileData, string $fileKey): ?string {
+    $sanitizer = new Sanitizer();
+    $sanitizer->removeRemoteReferences(TRUE);
+    try {
+      $clean = $sanitizer->sanitize($fileData);
+    }
+    catch (\Throwable) {
+      $clean = FALSE;
+    }
+    if (!is_string($clean) || trim($clean) === '' || preg_match('/<svg[\s>]/i', $clean) !== 1) {
+      $this->getLogger('markaspot_nuxt')->warning(
+        'Rejected invalid SVG logo upload for @key.',
+        ['@key' => $fileKey]
+      );
+      return NULL;
+    }
+
+    $clean = (string) preg_replace('/^<\?xml[^?]*\?>\s*/i', '', $clean);
+    $clean = (string) preg_replace('/<!DOCTYPE[^>]*>\s*/i', '', $clean);
+    $trimmed = trim($clean);
+
+    return $trimmed !== '' ? $trimmed : NULL;
+  }
+
+  /**
+   * Verifies PNG data using the file signature and image metadata.
+   */
+  protected function isPngImageData(string $fileData): bool {
+    if (!str_starts_with($fileData, "\x89PNG\r\n\x1A\n")) {
+      return FALSE;
+    }
+
+    $imageInfo = @getimagesizefromstring($fileData);
+    return is_array($imageInfo) && ($imageInfo[2] ?? NULL) === IMAGETYPE_PNG;
+  }
+
+  /**
+   * Validates and stores the client-generated PNG fallback for SVG mails.
+   *
+   * @return array
+   *   Result array with 'success' bool, 'url', or 'error'.
+   */
+  protected function saveLogoPngFallback(
+    UploadedFile $uploadedFile,
+    string $uploadDir,
+    string $safeSvgName,
+    string $fileKey,
+  ): array {
+    $extension = strtolower($uploadedFile->getClientOriginalExtension());
+    if ($extension !== 'png') {
+      return [
+        'success' => FALSE,
+        'error' => "Invalid PNG fallback for $fileKey.",
+      ];
+    }
+
+    $maxSizeBytes = 500 * 1024;
+    if ($uploadedFile->getSize() > $maxSizeBytes) {
+      return [
+        'success' => FALSE,
+        'error' => "PNG fallback too large for $fileKey. Maximum size is 500KB.",
+      ];
+    }
+
+    $fileData = file_get_contents($uploadedFile->getPathname());
+    if ($fileData === FALSE) {
+      return [
+        'success' => FALSE,
+        'error' => "Failed to read PNG fallback for $fileKey.",
+      ];
+    }
+
+    if (!$this->isPngImageData($fileData)) {
+      return [
+        'success' => FALSE,
+        'error' => "Invalid PNG fallback for $fileKey.",
+      ];
+    }
+
+    $baseName = pathinfo($safeSvgName, PATHINFO_FILENAME);
+    $destination = $uploadDir . '/' . $baseName . '.png';
+    try {
+      $uri = $this->fileSystem->saveData($fileData, $destination, FileSystemInterface::EXISTS_REPLACE);
+    }
+    catch (\Exception $e) {
+      $this->getLogger('markaspot_nuxt')->warning(
+        'PNG fallback save failed for @key: @message',
+        ['@key' => $fileKey, '@message' => $e->getMessage()]
+      );
+      return [
+        'success' => FALSE,
+        'error' => "PNG fallback save error for $fileKey: " . $e->getMessage(),
+      ];
+    }
+
+    if (!is_string($uri) || $uri === '') {
+      return [
+        'success' => FALSE,
+        'error' => "Failed to save PNG fallback for $fileKey.",
+      ];
+    }
+
+    return [
+      'success' => TRUE,
+      'uri' => $uri,
+      'url' => $this->buildPublicFileUrl($uri),
+    ];
+  }
+
+  /**
+   * Builds a public-facing relative file URL from a Drupal stream URI.
+   */
+  protected function buildPublicFileUrl(string $uri): string {
+    $scheme = StreamWrapperManager::getScheme($uri);
+    if ($scheme === 'public') {
+      $target = StreamWrapperManager::getTarget($uri);
+      $publicPath = PublicStream::basePath();
+      return '/' . $publicPath . '/' . $target;
+    }
+    return '/' . str_replace('://', '/', $uri);
   }
 
   /**
@@ -685,6 +853,7 @@ class TenantSettingsController extends ControllerBase {
 
     $deleted = [];
     $filesToDelete = [];
+    $fallbackUrisToDelete = [];
     $fileStorage = $this->entityTypeManager()->getStorage('file');
 
     foreach ($fieldsToDelete as $fieldName) {
@@ -698,6 +867,10 @@ class TenantSettingsController extends ControllerBase {
         $file = $fileStorage->load($fieldValue[0]['target_id']);
         if ($file) {
           $filesToDelete[] = $file;
+          $fallbackUri = $this->getLogoPngFallbackUri((string) $file->getFileUri());
+          if ($fallbackUri !== NULL) {
+            $fallbackUrisToDelete[] = $fallbackUri;
+          }
         }
       }
 
@@ -728,6 +901,9 @@ class TenantSettingsController extends ControllerBase {
     // Delete file entities only after successful group save.
     foreach ($filesToDelete as $file) {
       $file->delete();
+    }
+    foreach (array_unique($fallbackUrisToDelete) as $uri) {
+      $this->deleteFileIfReadable($uri);
     }
 
     $this->getLogger('markaspot_nuxt')->notice(
@@ -1375,8 +1551,8 @@ class TenantSettingsController extends ControllerBase {
     }
 
     // Apply only known feature flags from the request, preserving all others.
-    // Special case: formFirst can be an object with config options. When the
-    // dashboard sends true, preserve the existing object (don't flatten to bool).
+    // Special case: formFirst can be an object with config options. Preserve
+    // the existing object when the dashboard sends true.
     $allKnownFlags = array_merge(self::SIMPLE_FEATURE_FLAGS, self::NESTED_FEATURE_FLAGS);
     foreach ($data as $key => $value) {
       if (in_array($key, $allKnownFlags, TRUE)) {
@@ -1544,7 +1720,8 @@ class TenantSettingsController extends ControllerBase {
       }
     }
 
-    // Validate controls: allowlist known sub-keys, values must be boolean or object with enabled boolean.
+    // Validate controls: allowlist known sub-keys. Values must be boolean or
+    // an object with an enabled boolean.
     $validControls = ['zoom', 'tilt', 'theme', 'geolocation', 'heatmap', 'reports', 'attribution'];
     if (array_key_exists('controls', $data)) {
       if (!is_array($data['controls'])) {
@@ -2059,6 +2236,59 @@ class TenantSettingsController extends ControllerBase {
 
     // Return the current state (same shape as GET).
     return $this->getDashboardSettings($request, $jurisdiction_id);
+  }
+
+  /**
+   * Returns the current sidecar PNG fallback URI for a logo field.
+   */
+  protected function getExistingLogoPngFallbackUri($group, string $fieldName): ?string {
+    if (!$group->hasField($fieldName) || $group->get($fieldName)->isEmpty()) {
+      return NULL;
+    }
+
+    $field = $group->get($fieldName);
+    $file = $field->entity ?? NULL;
+    if ($file && method_exists($file, 'getFileUri')) {
+      return $this->getLogoPngFallbackUri((string) $file->getFileUri());
+    }
+
+    if (!method_exists($field, 'getValue')) {
+      return NULL;
+    }
+
+    $fieldValue = $field->getValue();
+    if (empty($fieldValue[0]['target_id'])) {
+      return NULL;
+    }
+
+    $storedFile = $this->entityTypeManager()
+      ->getStorage('file')
+      ->load($fieldValue[0]['target_id']);
+    if (!$storedFile || !method_exists($storedFile, 'getFileUri')) {
+      return NULL;
+    }
+
+    return $this->getLogoPngFallbackUri((string) $storedFile->getFileUri());
+  }
+
+  /**
+   * Returns the sidecar PNG fallback URI for an SVG logo URI.
+   */
+  protected function getLogoPngFallbackUri(string $uri): ?string {
+    if (preg_match('/\.svg$/i', $uri) !== 1) {
+      return NULL;
+    }
+    return (string) preg_replace('/\.svg$/i', '.png', $uri);
+  }
+
+  /**
+   * Deletes a file only when its stream wrapper resolves to a readable path.
+   */
+  protected function deleteFileIfReadable(string $uri): void {
+    $realpath = $this->fileSystem->realpath($uri);
+    if (is_string($realpath) && $realpath !== '' && is_readable($realpath)) {
+      $this->fileSystem->delete($uri);
+    }
   }
 
 }

--- a/modules/markaspot_nuxt/tests/src/Unit/TenantSettingsControllerTest.php
+++ b/modules/markaspot_nuxt/tests/src/Unit/TenantSettingsControllerTest.php
@@ -24,6 +24,7 @@ use Drupal\group\GroupMembershipLoaderInterface;
 use Drupal\markaspot_group\Service\JurisdictionHierarchyResolverInterface;
 use Drupal\markaspot_nuxt\Controller\TenantSettingsController;
 use Drupal\Tests\UnitTestCase;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -54,6 +55,27 @@ class TenantSettingsControllerTest extends UnitTestCase {
    * @var \Drupal\group\GroupMembershipLoaderInterface|\PHPUnit\Framework\MockObject\MockObject
    */
   protected GroupMembershipLoaderInterface $membershipLoader;
+
+  /**
+   * The mocked stream wrapper manager.
+   *
+   * @var \Drupal\Core\StreamWrapper\StreamWrapperManagerInterface|\PHPUnit\Framework\MockObject\MockObject
+   */
+  protected StreamWrapperManagerInterface $streamWrapperManager;
+
+  /**
+   * The mocked file system.
+   *
+   * @var \Drupal\Core\File\FileSystemInterface|\PHPUnit\Framework\MockObject\MockObject
+   */
+  protected FileSystemInterface $fileSystem;
+
+  /**
+   * The mocked file repository.
+   *
+   * @var \Drupal\file\FileRepositoryInterface|\PHPUnit\Framework\MockObject\MockObject
+   */
+  protected FileRepositoryInterface $fileRepository;
 
   /**
    * The mocked hierarchy resolver.
@@ -92,9 +114,9 @@ class TenantSettingsControllerTest extends UnitTestCase {
       });
 
     $this->membershipLoader = $this->createMock(GroupMembershipLoaderInterface::class);
-    $streamWrapperManager = $this->createMock(StreamWrapperManagerInterface::class);
-    $fileSystem = $this->createMock(FileSystemInterface::class);
-    $fileRepository = $this->createMock(FileRepositoryInterface::class);
+    $this->streamWrapperManager = $this->createMock(StreamWrapperManagerInterface::class);
+    $this->fileSystem = $this->createMock(FileSystemInterface::class);
+    $this->fileRepository = $this->createMock(FileRepositoryInterface::class);
     $this->currentUser = $this->createMock(AccountInterface::class);
     $this->currentUser->method('getDisplayName')->willReturn('testuser');
     $this->hierarchyResolver = $this->createMock(JurisdictionHierarchyResolverInterface::class);
@@ -113,9 +135,9 @@ class TenantSettingsControllerTest extends UnitTestCase {
     $container->set('config.factory', $configFactory);
     $container->set('entity_type.manager', $this->entityTypeManager);
     $container->set('group.membership_loader', $this->membershipLoader);
-    $container->set('stream_wrapper_manager', $streamWrapperManager);
-    $container->set('file_system', $fileSystem);
-    $container->set('file.repository', $fileRepository);
+    $container->set('stream_wrapper_manager', $this->streamWrapperManager);
+    $container->set('file_system', $this->fileSystem);
+    $container->set('file.repository', $this->fileRepository);
     $container->set('current_user', $this->currentUser);
     $container->set('markaspot_group.hierarchy_resolver', $this->hierarchyResolver);
     $container->set('email.validator', $emailValidator);
@@ -1329,6 +1351,81 @@ class TenantSettingsControllerTest extends UnitTestCase {
     $response = $this->controller->deleteLogo($request, '14');
 
     $this->assertEquals(400, $response->getStatusCode());
+  }
+
+  /**
+   * Tests saveLogoPngFallback() writes a sibling public PNG.
+   *
+   * @covers ::saveLogoPngFallback
+   */
+  public function testSaveLogoPngFallbackWritesSiblingPublicPng(): void {
+    $tmp = tempnam(sys_get_temp_dir(), 'logo-fallback-');
+    $this->assertIsString($tmp);
+    $png = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+    file_put_contents($tmp, base64_decode($png, TRUE));
+    $uploaded = new UploadedFile($tmp, 'logo.png', 'image/png', NULL, TRUE);
+
+    $this->fileSystem->expects($this->once())
+      ->method('saveData')
+      ->with(
+        $this->isType('string'),
+        'public://jurisdictions/14/logos/logo.png',
+        FileSystemInterface::EXISTS_REPLACE,
+      )
+      ->willReturn('public://jurisdictions/14/logos/logo.png');
+    $method = new \ReflectionMethod($this->controller, 'saveLogoPngFallback');
+    $result = $method->invoke(
+      $this->controller,
+      $uploaded,
+      'public://jurisdictions/14/logos',
+      'logo.svg',
+      'logo_light',
+    );
+
+    $this->assertTrue($result['success']);
+    $this->assertSame('public://jurisdictions/14/logos/logo.png', $result['uri']);
+    $this->assertSame('/sites/default/files/jurisdictions/14/logos/logo.png', $result['url']);
+    unlink($tmp);
+  }
+
+  /**
+   * Tests saveLogoPngFallback() rejects files with spoofed PNG metadata.
+   *
+   * @covers ::saveLogoPngFallback
+   */
+  public function testSaveLogoPngFallbackRejectsInvalidPngData(): void {
+    $tmp = tempnam(sys_get_temp_dir(), 'logo-fallback-');
+    $this->assertIsString($tmp);
+    file_put_contents($tmp, 'not a png');
+    $uploaded = new UploadedFile($tmp, 'logo.png', 'image/png', NULL, TRUE);
+
+    $this->fileSystem->expects($this->never())
+      ->method('saveData');
+
+    $method = new \ReflectionMethod($this->controller, 'saveLogoPngFallback');
+    $result = $method->invoke(
+      $this->controller,
+      $uploaded,
+      'public://jurisdictions/14/logos',
+      'logo.svg',
+      'logo_light',
+    );
+
+    $this->assertFalse($result['success']);
+    $this->assertSame('Invalid PNG fallback for logo_light.', $result['error']);
+    unlink($tmp);
+  }
+
+  /**
+   * Tests sanitizeSvgLogoData() rejects non-SVG markup.
+   *
+   * @covers ::sanitizeSvgLogoData
+   */
+  public function testSanitizeSvgLogoDataRejectsNonSvgMarkup(): void {
+    $method = new \ReflectionMethod($this->controller, 'sanitizeSvgLogoData');
+    $result = $method->invoke($this->controller, '<script>alert(1)</script>', 'logo_light');
+
+    $this->assertNull($result);
   }
 
 }

--- a/modules/markaspot_passwordless/config/install/language/de/markaspot_passwordless.mail.yml
+++ b/modules/markaspot_passwordless/config/install/language/de/markaspot_passwordless.mail.yml
@@ -1,6 +1,13 @@
 langcode: de
 verification_code:
   subject: '@platform_name: Ihr Bestätigungscode'
+  preheader: 'Ihr Bestätigungscode ist @minutes Minuten gültig.'
+  headline: 'Konto bestätigen'
+  subtext: 'Geben Sie diesen Code innerhalb der nächsten @minutes Minuten ein. Falls Sie den Code nicht angefordert haben, können Sie die E-Mail ignorieren.'
+  plain_text: |
+    Ihr Bestätigungscode: @code
+
+    Er läuft in @minutes Minuten ab.
   body: |
     Ihr Bestätigungscode lautet: @code
 

--- a/modules/markaspot_passwordless/config/install/markaspot_passwordless.mail.yml
+++ b/modules/markaspot_passwordless/config/install/markaspot_passwordless.mail.yml
@@ -1,6 +1,13 @@
 langcode: en
 verification_code:
   subject: '@platform_name: Your verification code'
+  preheader: 'Your verification code expires in @minutes minutes.'
+  headline: 'Verify your account'
+  subtext: 'Enter this code in the next @minutes minutes. If you did not request this, you can ignore this email.'
+  plain_text: |
+    Your verification code: @code
+
+    It expires in @minutes minutes.
   body: |
     Your verification code is: @code
 

--- a/modules/markaspot_passwordless/config/schema/markaspot_passwordless.schema.yml
+++ b/modules/markaspot_passwordless/config/schema/markaspot_passwordless.schema.yml
@@ -38,6 +38,18 @@ markaspot_passwordless.mail:
         subject:
           type: text
           label: 'Email subject'
+        preheader:
+          type: text
+          label: 'Email preheader'
+        headline:
+          type: text
+          label: 'Email headline'
+        subtext:
+          type: text
+          label: 'Email subtext'
+        plain_text:
+          type: text
+          label: 'Plain text email body'
         body:
           type: text
           label: 'Email body'

--- a/modules/markaspot_passwordless/markaspot_passwordless.install
+++ b/modules/markaspot_passwordless/markaspot_passwordless.install
@@ -336,3 +336,63 @@ function markaspot_passwordless_update_11906() {
 
   return t('Installed Czech passwordless mail translation.');
 }
+
+/**
+ * Repair German passwordless mail copy for existing sites.
+ */
+function markaspot_passwordless_update_11907() {
+  $language_manager = \Drupal::languageManager();
+
+  $base_config = \Drupal::configFactory()->getEditable('markaspot_passwordless.mail');
+  $base_mail = $base_config->get('verification_code') ?? [];
+  $base_legacy_body = is_string($base_mail['body'] ?? NULL) ? $base_mail['body'] : '';
+  $base_defaults = [
+    'subject' => '@platform_name: Your verification code',
+    'preheader' => 'Your verification code expires in @minutes minutes.',
+    'headline' => 'Verify your account',
+    'subtext' => 'Enter this code in the next @minutes minutes. If you did not request this, you can ignore this email.',
+    'plain_text' => trim($base_legacy_body) !== '' ? $base_legacy_body : "Your verification code: @code\n\nIt expires in @minutes minutes.",
+    'body' => "Your verification code is: @code\n\nThis code will expire in @expires_in minutes.\n\nIf you did not request this code, please ignore this email.\n",
+  ];
+  $base_added = [];
+  foreach ($base_defaults as $key => $value) {
+    if (empty($base_mail[$key]) || ($key === 'preheader' && $base_mail[$key] === 'Your verification code: @code')) {
+      $base_mail[$key] = $value;
+      $base_added[] = $key;
+    }
+  }
+  if ($base_added !== []) {
+    $base_config->set('verification_code', $base_mail)->save();
+  }
+
+  if (!$language_manager->getLanguage('de')) {
+    return t('German language is not installed; seeded English OTP mail defaults only.');
+  }
+
+  $override = $language_manager->getLanguageConfigOverride('de', 'markaspot_passwordless.mail');
+  $mail = $override->get('verification_code') ?? [];
+  $de_legacy_body = is_string($mail['body'] ?? NULL) ? $mail['body'] : '';
+  $de_defaults = [
+    'subject' => '@platform_name: Ihr Bestätigungscode',
+    'preheader' => 'Ihr Bestätigungscode ist @minutes Minuten gültig.',
+    'headline' => 'Konto bestätigen',
+    'subtext' => 'Geben Sie diesen Code innerhalb der nächsten @minutes Minuten ein. Falls Sie den Code nicht angefordert haben, können Sie die E-Mail ignorieren.',
+    'plain_text' => trim($de_legacy_body) !== '' ? $de_legacy_body : "Ihr Bestätigungscode: @code\n\nEr läuft in @minutes Minuten ab.",
+    'body' => "Ihr Bestätigungscode lautet: @code\n\nDieser Code ist @expires_in Minuten gültig.\n\nFalls Sie diesen Code nicht angefordert haben, können Sie diese E-Mail ignorieren.\n",
+  ];
+  $de_added = [];
+  foreach ($de_defaults as $key => $value) {
+    if (empty($mail[$key]) || ($key === 'preheader' && $mail[$key] === 'Ihr Bestätigungscode: @code')) {
+      $mail[$key] = $value;
+      $de_added[] = $key;
+    }
+  }
+  if ($de_added === []) {
+    return t('German passwordless mail copy already complete.');
+  }
+
+  $override->set('verification_code', $mail)->save();
+  return t('Seeded German passwordless mail copy: @keys.', [
+    '@keys' => implode(', ', $de_added),
+  ]);
+}

--- a/modules/markaspot_passwordless/src/Controller/PasswordlessAuthController.php
+++ b/modules/markaspot_passwordless/src/Controller/PasswordlessAuthController.php
@@ -1026,6 +1026,9 @@ class PasswordlessAuthController extends ControllerBase {
           'uuid' => $group->uuid(),
           'label' => $this->getEntityLabelForUserLanguage($group, $user),
           'type' => $is_jurisdiction_group ? 'jur' : $group->bundle(),
+          'slug' => ($is_jurisdiction_group && $group->hasField('field_slug') && !$group->get('field_slug')->isEmpty())
+            ? (string) $group->get('field_slug')->value
+            : NULL,
           'roles' => $group_roles,
         ];
       }

--- a/modules/markaspot_passwordless/src/Controller/PasswordlessAuthController.php
+++ b/modules/markaspot_passwordless/src/Controller/PasswordlessAuthController.php
@@ -1021,14 +1021,27 @@ class PasswordlessAuthController extends ControllerBase {
           ];
         }
 
+        $slug = NULL;
+        if ($is_jurisdiction_group && $group->hasField('field_slug') && !$group->get('field_slug')->isEmpty()) {
+          $candidate = trim((string) $group->get('field_slug')->value);
+          // Reject digit-only slugs to keep the client-side scope guard
+          // (markaspot-ui#438) free of slug/numeric-id collisions, where a
+          // membership in slug "42" would otherwise grant scope access to the
+          // unrelated numeric group 42.
+          if ($candidate !== ''
+            && preg_match('/^[a-z0-9_-]{1,64}$/', $candidate)
+            && !ctype_digit($candidate)
+          ) {
+            $slug = $candidate;
+          }
+        }
+
         $groups[] = [
           'id' => $group->id(),
           'uuid' => $group->uuid(),
           'label' => $this->getEntityLabelForUserLanguage($group, $user),
           'type' => $is_jurisdiction_group ? 'jur' : $group->bundle(),
-          'slug' => ($is_jurisdiction_group && $group->hasField('field_slug') && !$group->get('field_slug')->isEmpty())
-            ? (string) $group->get('field_slug')->value
-            : NULL,
+          'slug' => $slug,
           'roles' => $group_roles,
         ];
       }

--- a/modules/markaspot_passwordless/src/Form/PasswordlessSettingsForm.php
+++ b/modules/markaspot_passwordless/src/Form/PasswordlessSettingsForm.php
@@ -118,15 +118,49 @@ class PasswordlessSettingsForm extends ConfigFormBase {
     $form['mail']['mail_subject'] = [
       '#type' => 'textfield',
       '#title' => $this->t('Subject'),
-      '#description' => $this->t('Available tokens: @code, @expires_in, @platform_name'),
+      '#description' => $this->t('Available tokens: @expires_in, @minutes, @platform_name. @code is intentionally not rendered in the subject.'),
       '#default_value' => $mail_config->get('verification_code.subject') ?? '',
+      '#required' => TRUE,
+    ];
+
+    $form['mail']['mail_preheader'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Preheader'),
+      '#description' => $this->t('Inbox preview text. Available tokens: @expires_in, @minutes, @platform_name. @code is intentionally not rendered in the preheader.'),
+      '#default_value' => $mail_config->get('verification_code.preheader') ?? '',
+      '#required' => TRUE,
+    ];
+
+    $form['mail']['mail_headline'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Headline'),
+      '#description' => $this->t('Headline shown above the code. Available tokens: @code, @expires_in, @minutes, @platform_name.'),
+      '#default_value' => $mail_config->get('verification_code.headline') ?? '',
+      '#required' => TRUE,
+    ];
+
+    $form['mail']['mail_subtext'] = [
+      '#type' => 'textarea',
+      '#title' => $this->t('Subtext'),
+      '#description' => $this->t('Text shown below the code. Available tokens: @code, @expires_in, @minutes, @platform_name.'),
+      '#default_value' => $mail_config->get('verification_code.subtext') ?? '',
+      '#rows' => 3,
+      '#required' => TRUE,
+    ];
+
+    $form['mail']['mail_plain_text'] = [
+      '#type' => 'textarea',
+      '#title' => $this->t('Plain text body'),
+      '#description' => $this->t('Plain text fallback. Available tokens: @code, @expires_in, @minutes, @platform_name.'),
+      '#default_value' => $mail_config->get('verification_code.plain_text') ?? '',
+      '#rows' => 5,
       '#required' => TRUE,
     ];
 
     $form['mail']['mail_body'] = [
       '#type' => 'textarea',
-      '#title' => $this->t('Body'),
-      '#description' => $this->t('Available tokens: @code, @expires_in, @platform_name. The jurisdiction email footer is appended automatically.'),
+      '#title' => $this->t('Legacy body'),
+      '#description' => $this->t('Legacy fallback for older templates and locale overrides. Available tokens: @code, @expires_in, @minutes, @platform_name. The jurisdiction email footer is appended automatically.'),
       '#default_value' => $mail_config->get('verification_code.body') ?? '',
       '#rows' => 8,
       '#required' => TRUE,
@@ -185,6 +219,10 @@ class PasswordlessSettingsForm extends ConfigFormBase {
 
     $this->config('markaspot_passwordless.mail')
       ->set('verification_code.subject', $form_state->getValue('mail_subject'))
+      ->set('verification_code.preheader', $form_state->getValue('mail_preheader'))
+      ->set('verification_code.headline', $form_state->getValue('mail_headline'))
+      ->set('verification_code.subtext', $form_state->getValue('mail_subtext'))
+      ->set('verification_code.plain_text', $form_state->getValue('mail_plain_text'))
       ->set('verification_code.body', $form_state->getValue('mail_body'))
       ->save();
 

--- a/modules/markaspot_passwordless/tests/src/Unit/PasswordlessAuthControllerTest.php
+++ b/modules/markaspot_passwordless/tests/src/Unit/PasswordlessAuthControllerTest.php
@@ -500,6 +500,100 @@ class PasswordlessAuthControllerTest extends UnitTestCase {
   }
 
   /**
+   * Tests digit-only slugs are rejected to avoid numeric-id collisions.
+   *
+   * @covers ::getUserGroups
+   */
+  public function testGetUserGroupsRejectsDigitOnlySlug(): void {
+    $user = $this->createMock(UserInterface::class);
+    $user->method('getPreferredLangcode')->with(FALSE)->willReturn('');
+
+    $slugFieldItem = new class {
+
+      /**
+       * The field value.
+       *
+       * @var string
+       */
+      public string $value = '42';
+
+      /**
+       * Whether the field is empty.
+       */
+      public function isEmpty(): bool {
+        return FALSE;
+      }
+
+    };
+
+    $group = $this->createMock(GroupInterface::class);
+    $group->method('id')->willReturn(5);
+    $group->method('uuid')->willReturn('group-uuid');
+    $group->method('bundle')->willReturn('jur');
+    $group->method('label')->willReturn('Numeric Slug');
+    $group->method('hasField')
+      ->willReturnCallback(static fn(string $name) => $name === 'field_slug');
+    $group->method('get')
+      ->willReturnCallback(static fn(string $name) => $name === 'field_slug' ? $slugFieldItem : NULL);
+
+    $role = $this->createMock(GroupRoleInterface::class);
+    $role->method('id')->willReturn('jur-tenant_admin');
+    $role->method('label')->willReturn('Tenant admin');
+
+    $membership = new class($group, $role) {
+
+      public function __construct(
+        private readonly GroupInterface $group,
+        private readonly GroupRoleInterface $role,
+      ) {}
+
+      /**
+       * Gets the membership group.
+       */
+      public function getGroup(): GroupInterface {
+        return $this->group;
+      }
+
+      /**
+       * Gets the membership roles.
+       */
+      public function getRoles(): array {
+        return [$this->role];
+      }
+
+    };
+
+    $membershipLoader = $this->createMock(GroupMembershipLoaderInterface::class);
+    $membershipLoader->expects($this->once())
+      ->method('loadByUser')
+      ->with($user)
+      ->willReturn([$membership]);
+
+    $moduleHandler = $this->createMock(ModuleHandlerInterface::class);
+    $moduleHandler->method('moduleExists')->with('group')->willReturn(TRUE);
+
+    $container = \Drupal::getContainer();
+    $container->set('module_handler', $moduleHandler);
+    $container->set('group.membership_loader', $membershipLoader);
+
+    $controller = new PasswordlessAuthController(
+      $this->otpService,
+      $this->currentUser,
+      $this->flood,
+      $this->configFactory,
+      $this->sessionConfiguration,
+      $this->keyValueExpirable,
+      $this->featureFlagChecker,
+    );
+
+    $method = new \ReflectionMethod($controller, 'getUserGroups');
+    $method->setAccessible(TRUE);
+
+    $result = $method->invoke($controller, $user);
+    $this->assertNull($result[0]['slug']);
+  }
+
+  /**
    * Tests org groups never get a slug populated even if field is present.
    *
    * @covers ::getUserGroups

--- a/modules/markaspot_passwordless/tests/src/Unit/PasswordlessAuthControllerTest.php
+++ b/modules/markaspot_passwordless/tests/src/Unit/PasswordlessAuthControllerTest.php
@@ -299,6 +299,7 @@ class PasswordlessAuthControllerTest extends UnitTestCase {
         'uuid' => 'group-uuid',
         'label' => 'Strassen',
         'type' => 'jur',
+        'slug' => NULL,
         'roles' => [
           [
             'id' => 'jur-member',
@@ -392,6 +393,7 @@ class PasswordlessAuthControllerTest extends UnitTestCase {
         'uuid' => 'group-uuid',
         'label' => 'Roads',
         'type' => 'jur',
+        'slug' => NULL,
         'roles' => [
           [
             'id' => 'jur-tenant_admin',
@@ -400,6 +402,174 @@ class PasswordlessAuthControllerTest extends UnitTestCase {
         ],
       ],
     ], $method->invoke($controller, $user));
+  }
+
+  /**
+   * Tests jur groups with field_slug emit slug for client-side scope guards.
+   *
+   * @covers ::getUserGroups
+   */
+  public function testGetUserGroupsEmitsSlugForJurisdictionGroupsWithSlug(): void {
+    $user = $this->createMock(UserInterface::class);
+    $user->method('getPreferredLangcode')->with(FALSE)->willReturn('');
+
+    $slugFieldItem = new class {
+
+      /**
+       * The field value.
+       *
+       * @var string
+       */
+      public string $value = 'amsterdam';
+
+      /**
+       * Whether the field is empty.
+       */
+      public function isEmpty(): bool {
+        return FALSE;
+      }
+
+    };
+
+    $group = $this->createMock(GroupInterface::class);
+    $group->method('id')->willReturn(5);
+    $group->method('uuid')->willReturn('group-uuid');
+    $group->method('bundle')->willReturn('jur');
+    $group->method('label')->willReturn('Amsterdam');
+    $group->method('hasField')
+      ->willReturnCallback(static fn(string $name) => $name === 'field_slug');
+    $group->method('get')
+      ->willReturnCallback(static fn(string $name) => $name === 'field_slug' ? $slugFieldItem : NULL);
+
+    $role = $this->createMock(GroupRoleInterface::class);
+    $role->method('id')->willReturn('jur-tenant_admin');
+    $role->method('label')->willReturn('Tenant admin');
+
+    $membership = new class($group, $role) {
+
+      public function __construct(
+        private readonly GroupInterface $group,
+        private readonly GroupRoleInterface $role,
+      ) {}
+
+      /**
+       * Gets the membership group.
+       */
+      public function getGroup(): GroupInterface {
+        return $this->group;
+      }
+
+      /**
+       * Gets the membership roles.
+       */
+      public function getRoles(): array {
+        return [$this->role];
+      }
+
+    };
+
+    $membershipLoader = $this->createMock(GroupMembershipLoaderInterface::class);
+    $membershipLoader->expects($this->once())
+      ->method('loadByUser')
+      ->with($user)
+      ->willReturn([$membership]);
+
+    $moduleHandler = $this->createMock(ModuleHandlerInterface::class);
+    $moduleHandler->method('moduleExists')->with('group')->willReturn(TRUE);
+
+    $container = \Drupal::getContainer();
+    $container->set('module_handler', $moduleHandler);
+    $container->set('group.membership_loader', $membershipLoader);
+
+    $controller = new PasswordlessAuthController(
+      $this->otpService,
+      $this->currentUser,
+      $this->flood,
+      $this->configFactory,
+      $this->sessionConfiguration,
+      $this->keyValueExpirable,
+      $this->featureFlagChecker,
+    );
+
+    $method = new \ReflectionMethod($controller, 'getUserGroups');
+    $method->setAccessible(TRUE);
+
+    $result = $method->invoke($controller, $user);
+    $this->assertSame('amsterdam', $result[0]['slug']);
+    $this->assertSame('jur', $result[0]['type']);
+  }
+
+  /**
+   * Tests org groups never get a slug populated even if field is present.
+   *
+   * @covers ::getUserGroups
+   */
+  public function testGetUserGroupsEmitsNullSlugForOrgGroups(): void {
+    $user = $this->createMock(UserInterface::class);
+    $user->method('getPreferredLangcode')->with(FALSE)->willReturn('');
+
+    $group = $this->createMock(GroupInterface::class);
+    $group->method('id')->willReturn(7);
+    $group->method('uuid')->willReturn('org-uuid');
+    $group->method('bundle')->willReturn('org');
+    $group->method('label')->willReturn('Roads Department');
+
+    $role = $this->createMock(GroupRoleInterface::class);
+    $role->method('id')->willReturn('org-member');
+    $role->method('label')->willReturn('Member');
+
+    $membership = new class($group, $role) {
+
+      public function __construct(
+        private readonly GroupInterface $group,
+        private readonly GroupRoleInterface $role,
+      ) {}
+
+      /**
+       * Gets the membership group.
+       */
+      public function getGroup(): GroupInterface {
+        return $this->group;
+      }
+
+      /**
+       * Gets the membership roles.
+       */
+      public function getRoles(): array {
+        return [$this->role];
+      }
+
+    };
+
+    $membershipLoader = $this->createMock(GroupMembershipLoaderInterface::class);
+    $membershipLoader->expects($this->once())
+      ->method('loadByUser')
+      ->with($user)
+      ->willReturn([$membership]);
+
+    $moduleHandler = $this->createMock(ModuleHandlerInterface::class);
+    $moduleHandler->method('moduleExists')->with('group')->willReturn(TRUE);
+
+    $container = \Drupal::getContainer();
+    $container->set('module_handler', $moduleHandler);
+    $container->set('group.membership_loader', $membershipLoader);
+
+    $controller = new PasswordlessAuthController(
+      $this->otpService,
+      $this->currentUser,
+      $this->flood,
+      $this->configFactory,
+      $this->sessionConfiguration,
+      $this->keyValueExpirable,
+      $this->featureFlagChecker,
+    );
+
+    $method = new \ReflectionMethod($controller, 'getUserGroups');
+    $method->setAccessible(TRUE);
+
+    $result = $method->invoke($controller, $user);
+    $this->assertNull($result[0]['slug']);
+    $this->assertSame('org', $result[0]['type']);
   }
 
   /**


### PR DESCRIPTION
## Summary

- Adds a `slug` field to each `jur` group entry in the `auth_user` response (`null` for `org` groups, `null` for legacy `jur` groups without `field_slug`).
- Slug emission is hardened: trim, regex `^[a-z0-9_-]{1,64}$`, and rejection of digit-only slugs to prevent collision with numeric group ids in the Nuxt scope guard.
- Two unit tests cover the canonical contract (jur-with-slug, org-with-null), one additional test covers digit-only rejection.

## Why

Unblocks the client-side fix for [markaspot-ui#438](https://github.com/markaspot/markaspot-ui/issues/438): the Nuxt scope validator (`useApiClient.validateCustomApiScope`) compares URL path segments against `auth_user.groups[].id` (numeric), but FastMap mode uses slug-form jurisdiction params. Exposing the slug here lets the validator accept either form without coupling its lookup Set to dashboard state.

The pattern (trim + regex + digit-only rejection) mirrors `markaspot_group::GroupInvitationController::getJurisdictionSlug`, so it stays in sync with the canonical slug filter.

## Test plan

- [x] PHPUnit `PasswordlessAuthControllerTest` — 33/33 green (jur-with-slug emission, org-null contract, digit-only rejection)
- [ ] Manual: tenant_admin (no global `administrator`) on `/amsterdam/dashboard/settings/branding` saves theme colors successfully (no client-side 403)
- [ ] Manual: legacy `jur` group without `field_slug` returns `slug: null`, frontend continues to use numeric form